### PR TITLE
fix: replace Google Fonts with local CSS variable fallbacks to fix of…

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,11 @@
 
 @layer base {
   :root {
+    /* Font family variables - defined here as fallbacks when Google Fonts are unavailable */
+    --font-inter: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    --font-playfair: Georgia, 'Times New Roman', serif;
+    --font-space-mono: 'Courier New', Courier, monospace;
+
     /* Base theme colors */
     --background: 222 33% 5%;
     --foreground: 0 0% 100%;

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -1,32 +1,9 @@
-import { Inter, Space_Mono, Playfair_Display } from 'next/font/google';
 import localFont from 'next/font/local';
 import { Analytics } from "@vercel/analytics/react";
 import './globals.css';
 
 // Set revalidation time to 6 hours (21600 seconds) for all pages
 export const revalidate = 21600;
-
-// Define our fonts
-const playfair = Playfair_Display({
-  subsets: ['latin'],
-  display: 'swap',
-  variable: '--font-playfair',
-  // Using Playfair Display as an alternative to GT Sectra
-});
-
-const spaceMono = Space_Mono({
-  subsets: ['latin'],
-  weight: ['400', '700'],
-  display: 'swap',
-  variable: '--font-space-mono',
-});
-
-// Using Inter as a fallback for Switzer
-const inter = Inter({
-  subsets: ['latin'],
-  display: 'swap',
-  variable: '--font-inter',
-});
 
 // Define the switzer font
 const switzer = localFont({
@@ -117,7 +94,7 @@ export default function RootLayout({ children }) {
   return (
     <html
       lang="en"
-      className={`${playfair.variable} ${spaceMono.variable} ${inter.variable} ${switzer.variable}`}
+      className={`${switzer.variable}`}
     >
       <head>
         <link rel="manifest" href="/manifest.json" />


### PR DESCRIPTION
…fline build

Remove next/font/google imports (Inter, Space_Mono, Playfair_Display) that fail when network is unavailable, and define --font-inter, --font-playfair, --font-space-mono CSS variables directly in :root with system font stacks.

https://claude.ai/code/session_01NbaHTG4rUMPdwG4yu4z4iH

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to font loading and CSS variables, with the main impact being potential typography/metrics differences if the previous Google fonts were expected.
> 
> **Overview**
> Removes `next/font/google` usage for `Inter`, `Space_Mono`, and `Playfair_Display` in `layout.js` and stops injecting their font variables on the `<html>` element, leaving only the local `Switzer` font.
> 
> Adds `:root` CSS variables (`--font-inter`, `--font-playfair`, `--font-space-mono`) in `globals.css` using system font stacks so existing `var(--font-*)` references keep working without network-dependent Google font fetching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe4108582c2a5f66a7218e357fbb1398a74c7c6e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->