### PR TITLE
feat: clarify Wobble section with 3D precession cone

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "next-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/src/components/story/PrecessionSection.jsx
+++ b/src/components/story/PrecessionSection.jsx
@@ -8,7 +8,7 @@ import { TemperatureIndicator } from "./TemperatureIndicator";
 export function PrecessionSection({ precession, onPrecessionChange, temperature, onInView }) {
   return (
     <StorySection id={4} onInView={onInView}>
-      <div className="w-full max-w-lg px-6 md:px-12 py-8">
+      <div className="w-full max-w-lg px-6 md:px-12 py-8 md:ml-auto">
         <div className="observatory-panel p-6 md:p-8 space-y-6">
           <div>
             <h2 className="text-3xl md:text-4xl mb-1">The Wobble</h2>
@@ -16,14 +16,16 @@ export function PrecessionSection({ precession, onPrecessionChange, temperature,
           </div>
 
           <p className="text-base text-stardust-white opacity-80 leading-relaxed">
-            Earth's axis slowly wobbles in a circle, like a spinning top that's winding
-            down. One full wobble takes about <strong className="text-pale-gold">26,000 years</strong>.
+            Earth's tilt doesn't just lean — the <em>direction</em> of that lean slowly
+            traces a circle, like a spinning top winding down. One full cycle takes
+            about <strong className="text-pale-gold">26,000 years</strong>.
           </p>
 
           <p className="text-sm text-stardust-white opacity-60 leading-relaxed italic">
+            Watch the dashed circle in the 3D view — that's the path the axis traces.
             This wobble changes which season happens when Earth is closest to the Sun.
-            Right now, Northern Hemisphere winter happens near the closest point.
-            In 13,000 years, it'll be summer instead.
+            Right now, northern winters happen near the closest point.
+            In 13,000 years, northern summers will instead.
           </p>
 
           <StorySlider
@@ -34,9 +36,9 @@ export function PrecessionSection({ precession, onPrecessionChange, temperature,
             min={0}
             max={360}
             step={1}
-            hint="Notice which hemisphere points sunward at closest approach"
-            minLabel="Current orientation"
-            maxLabel="Full wobble"
+            hint="Watch the axis tip move along the dashed circle above"
+            minLabel="Today's orientation"
+            maxLabel="Full cycle (back to start)"
             formatValue={(nextValue) => `${nextValue.toFixed(0)}°`}
           />
 

--- a/src/components/story/SceneController.jsx
+++ b/src/components/story/SceneController.jsx
@@ -33,9 +33,9 @@ const SCENE_CONFIGS = {
     showOrbit: false,
     showAxis: true,
   },
-  4: { // Precession - angled view
-    camera: [15, 25, 35],
-    lookAt: [0, 0, 0],
+  4: { // Precession - same view as tilt section, with orbit for seasonal context
+    camera: [18, 5, 15],
+    lookAt: [20, 0, 0],
     showSun: true,
     showOrbit: true,
     showAxis: true,

--- a/src/components/three/AxisIndicators.jsx
+++ b/src/components/three/AxisIndicators.jsx
@@ -1,7 +1,7 @@
 "use client";
 import React, { useEffect, useMemo } from "react";
 import * as THREE from "three";
-import { Html } from "@react-three/drei";
+import { Html, Line } from "@react-three/drei";
 
 export const AxisIndicators = React.memo(function AxisIndicators() {
   const arrow = useMemo(
@@ -48,3 +48,95 @@ export const AxisIndicators = React.memo(function AxisIndicators() {
     </group>
   );
 });
+
+/**
+ * Wobble cone — a dashed circle showing the path the axis tip traces
+ * as precession changes. Rendered OUTSIDE the Earth's quaternion group
+ * so it stays fixed while the axis moves through it.
+ */
+export function PrecessionCone({ axialTilt, precession, visible }) {
+  const { conePoints, spokeLines, markerPos } = useMemo(() => {
+    const tiltRad = THREE.MathUtils.degToRad(axialTilt);
+    const axisLength = 5;
+    const radius = axisLength * Math.sin(tiltRad);
+    const height = axisLength * Math.cos(tiltRad);
+    const origin = new THREE.Vector3(0, 0, 0);
+
+    // Dashed circle at the rim of the cone (wobble path)
+    const pts = [];
+    const segments = 64;
+    for (let i = 0; i <= segments; i++) {
+      const angle = (i / segments) * Math.PI * 2;
+      pts.push(new THREE.Vector3(radius * Math.cos(angle), height, radius * Math.sin(angle)));
+    }
+
+    // 8 evenly-spaced spokes from origin up to the rim — makes the cone 3D shape obvious
+    const spokes = [];
+    for (let i = 0; i < 8; i++) {
+      const angle = (i / 8) * Math.PI * 2;
+      spokes.push([
+        origin.clone(),
+        new THREE.Vector3(radius * Math.cos(angle), height, radius * Math.sin(angle)),
+      ]);
+    }
+
+    // Current axis-tip position on the cone rim
+    const precRad = THREE.MathUtils.degToRad(precession);
+    const mx = radius * Math.cos(precRad);
+    const mz = radius * Math.sin(precRad);
+
+    return { conePoints: pts, spokeLines: spokes, markerPos: [mx, height, mz] };
+  }, [axialTilt, precession]);
+
+  if (!visible) return null;
+
+  return (
+    <group>
+      {/* Cone spokes from Earth centre to rim — shows the 3D cone shape */}
+      {spokeLines.map((pts, i) => (
+        <Line
+          key={i}
+          points={pts}
+          color="#cdaf7d"
+          lineWidth={1}
+          transparent
+          opacity={0.18}
+        />
+      ))}
+
+      {/* Dashed circle at rim — the wobble path */}
+      <Line
+        points={conePoints}
+        color="#e8d0a9"
+        lineWidth={2}
+        transparent
+        opacity={0.55}
+        dashed
+        dashSize={0.3}
+        gapSize={0.2}
+      />
+
+      {/* Vertical "true north" reference — so you can see the axis leaning away */}
+      <Line
+        points={[new THREE.Vector3(0, 0, 0), new THREE.Vector3(0, 5.2, 0)]}
+        color="#4a9eff"
+        lineWidth={1}
+        transparent
+        opacity={0.3}
+        dashed
+        dashSize={0.25}
+        gapSize={0.25}
+      />
+
+      {/* Bright marker dot at current axis-tip position */}
+      <mesh position={markerPos}>
+        <sphereGeometry args={[0.2, 12, 12]} />
+        <meshBasicMaterial color="#fbbf24" />
+      </mesh>
+      <mesh position={markerPos} scale={2.2}>
+        <sphereGeometry args={[0.2, 12, 12]} />
+        <meshBasicMaterial color="#fbbf24" transparent opacity={0.25} />
+      </mesh>
+    </group>
+  );
+}

--- a/src/components/three/Earth.jsx
+++ b/src/components/three/Earth.jsx
@@ -91,10 +91,6 @@ export const Earth = React.forwardRef(
       }
     });
 
-    if (!texturesLoaded || !uniforms || !textures) {
-      return null;
-    }
-
     const combinedQuaternion = useMemo(() => {
       const tiltQuaternion = new THREE.Quaternion().setFromAxisAngle(
         new THREE.Vector3(0, 0, 1),
@@ -106,6 +102,10 @@ export const Earth = React.forwardRef(
       );
       return tiltQuaternion.multiply(precessionQuaternion);
     }, [axialTilt, precession]);
+
+    if (!texturesLoaded || !uniforms || !textures) {
+      return null;
+    }
 
     return (
       <group quaternion={combinedQuaternion}>

--- a/src/components/three/OrbitingEarth.jsx
+++ b/src/components/three/OrbitingEarth.jsx
@@ -3,6 +3,7 @@ import React, { useRef, useState, useEffect, useCallback } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 import { Earth } from "./Earth";
+import { PrecessionCone } from "./AxisIndicators";
 
 export function OrbitingEarth({
   eccentricity,
@@ -29,15 +30,15 @@ export function OrbitingEarth({
   useFrame((_, delta) => {
     if (!groupRef.current || !isReady) return;
 
-    const isTiltFocusSection = currentSection === 3;
-    if (!isTiltFocusSection) {
+    const isPinnedSection = currentSection === 3 || currentSection === 4;
+    if (!isPinnedSection) {
       orbitThetaRef.current += delta * 0.1;
     }
 
-    const targetTheta = isTiltFocusSection ? 0 : orbitThetaRef.current;
+    const targetTheta = isPinnedSection ? 0 : orbitThetaRef.current;
     const targetX = a * Math.cos(targetTheta);
     const targetZ = b * Math.sin(targetTheta);
-    const easing = isTiltFocusSection ? 0.16 : 0.08;
+    const easing = isPinnedSection ? 0.16 : 0.08;
 
     groupRef.current.position.x = THREE.MathUtils.lerp(
       groupRef.current.position.x,
@@ -51,11 +52,16 @@ export function OrbitingEarth({
     );
 
     if (earthRef.current) {
-      earthRef.current.rotation.y += 0.01;
+      // Slow rotation during precession section so wobble is the main visible motion
+      const rotSpeed = currentSection === 4 ? 0.002 : 0.01;
+      earthRef.current.rotation.y += rotSpeed;
     }
   });
 
   const onEarthReady = useCallback(() => setIsReady(true), []);
+
+  // Show the precession cone in sections where precession is relevant
+  const showPrecessionCone = showAxis && (currentSection === 4 || currentSection === 5 || currentSection === 6);
 
   return (
     <group ref={groupRef}>
@@ -66,6 +72,12 @@ export function OrbitingEarth({
         iceFactor={iceFactor}
         onReady={onEarthReady}
         showAxis={showAxis}
+      />
+      {/* Precession cone is outside Earth's quaternion group so it stays fixed */}
+      <PrecessionCone
+        axialTilt={axialTilt}
+        precession={precession}
+        visible={showPrecessionCone}
       />
     </group>
   );


### PR DESCRIPTION
## Summary

- **3D precession cone**: new `PrecessionCone` component renders a spinning-top shape — 8 spoke lines from Earth's centre to a dashed rim circle, plus a blue vertical reference line so users can immediately see the axis leaning away from straight up
- **Golden marker** tracks the axis tip around the rim as the precession slider moves
- **Earth pinned** during section 4 (matches Tilt section behaviour) so it stays in frame
- **Slower daily spin** (1/5 speed) during precession section so the wobble is the dominant visible motion
- **Camera angle** updated to match the close Tilt section view, with orbit visible for seasonal context
- **Panel alignment** (`md:ml-auto`) pushes text to the right so the cone is unobstructed on desktop
- **Improved copy**: explains the *direction* of the lean traces a circle, directs users to watch the dashed circle, better slider hint and labels

## Test plan

- [ ] Scroll to "The Wobble" section — 3D cone shape (spokes + dashed rim + blue vertical) visible on the right
- [ ] Drag precession slider — golden dot moves around rim, axis arrow follows it
- [ ] Confirm Earth stays pinned (doesn't orbit away) when on section 4
- [ ] Confirm Earth rotation is noticeably slower during section 4
- [ ] Check layout on desktop (1280px+) — panel on right, cone unobstructed on left
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to UI/3D visualization behavior and copy/layout tweaks, with no auth, persistence, or data-handling logic affected.
> 
> **Overview**
> Clarifies the *Wobble / precession* story step by adding a new `PrecessionCone` 3D overlay (dashed rim circle, spokes, vertical reference line, and a marker that tracks the axis tip as `precession` changes) rendered alongside Earth.
> 
> Updates section 4 behavior to keep Earth *pinned in frame* (like the tilt section), slow Earth’s spin during that section, and align the camera view with the tilt section while keeping the orbit visible. Also adjusts the Precession panel layout (`md:ml-auto`) and refreshes explanatory copy plus slider hint/labels.
> 
> Adds a `.claude/launch.json` config for running `npm run dev` on port 3000.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e4cd077f5e5d7bf5cc2f8a80dda4df07cdf43b1. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->