### PR TITLE
feat: modernize 3D graphics with bloom, normal mapping, and atmospher…

### DIFF
--- a/src/components/story/StoryContainer.jsx
+++ b/src/components/story/StoryContainer.jsx
@@ -2,6 +2,7 @@
 import React, { useState, useCallback, useEffect, Suspense, useRef } from "react";
 import { Canvas } from "@react-three/fiber";
 import { OrbitControls, PerspectiveCamera } from "@react-three/drei";
+import * as THREE from "three";
 
 import { Sun } from "@/components/three/Sun";
 import { OrbitPath } from "@/components/three/OrbitPath";
@@ -170,9 +171,10 @@ export function StoryContainer() {
             gl={{
               antialias: true,
               powerPreference: "high-performance",
-              precision: "mediump",
+              precision: "highp",
+              toneMapping: THREE.NoToneMapping,
             }}
-            dpr={[1, 1]}
+            dpr={[1, 2]}
             performance={{ min: 0.5 }}
           >
             <PerspectiveCamera
@@ -227,8 +229,8 @@ export function StoryContainer() {
               />
             )}
 
-            {/* Post-processing effects - disabled on mobile */}
-            {!isMobile && <SceneEffects />}
+            {/* Post-processing effects */}
+            <SceneEffects isMobile={isMobile} />
           </Canvas>
         </Suspense>
       </div>

--- a/src/components/three/Earth.jsx
+++ b/src/components/three/Earth.jsx
@@ -2,7 +2,12 @@
 import React, { useRef, useState, useEffect, useMemo } from "react";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
-import { earthVertexShader, earthFragmentShader } from "./shaders";
+import {
+  earthVertexShader,
+  earthFragmentShader,
+  atmosphereVertexShader,
+  atmosphereFragmentShader,
+} from "./shaders";
 import { AxisIndicators } from "./AxisIndicators";
 
 export const Earth = React.forwardRef(
@@ -68,6 +73,13 @@ export const Earth = React.forwardRef(
       };
     }, [texturesLoaded, textures]);
 
+    const atmosphereUniforms = useMemo(() => {
+      if (!uniforms) return null;
+      return {
+        sunDirection: uniforms.sunDirection,
+      };
+    }, [uniforms]);
+
     useEffect(() => {
       if (uniforms) {
         uniforms.iceFactor.value = iceFactor;
@@ -110,7 +122,7 @@ export const Earth = React.forwardRef(
     return (
       <group quaternion={combinedQuaternion}>
         <mesh ref={ref} castShadow receiveShadow>
-          <sphereGeometry args={[1, 48, 48]} />
+          <sphereGeometry args={[1, 64, 64]} />
           <shaderMaterial
             fragmentShader={earthFragmentShader}
             vertexShader={earthVertexShader}
@@ -130,13 +142,27 @@ export const Earth = React.forwardRef(
           />
         </mesh>
 
-        <mesh scale={1.03}>
+        <mesh scale={1.015}>
           <sphereGeometry args={[1, 32, 32]} />
           <meshBasicMaterial
             color="#a8d0e6"
             transparent={true}
             opacity={iceFactor * 0.5}
             depthWrite={false}
+          />
+        </mesh>
+
+        {/* Atmosphere glow shell */}
+        <mesh scale={1.06}>
+          <sphereGeometry args={[1, 48, 48]} />
+          <shaderMaterial
+            transparent={true}
+            depthWrite={false}
+            side={THREE.BackSide}
+            blending={THREE.AdditiveBlending}
+            vertexShader={atmosphereVertexShader}
+            fragmentShader={atmosphereFragmentShader}
+            uniforms={atmosphereUniforms}
           />
         </mesh>
 

--- a/src/components/three/SceneEffects.jsx
+++ b/src/components/three/SceneEffects.jsx
@@ -1,15 +1,29 @@
 "use client";
 import React from "react";
-import { EffectComposer, Noise, Vignette } from "@react-three/postprocessing";
-import { BlendFunction } from "postprocessing";
+import {
+  EffectComposer,
+  Noise,
+  Vignette,
+  Bloom,
+  ToneMapping,
+} from "@react-three/postprocessing";
+import { BlendFunction, ToneMappingMode } from "postprocessing";
 
-export function SceneEffects() {
+export function SceneEffects({ isMobile = false }) {
   return (
     <EffectComposer multisampling={0}>
+      <Bloom
+        intensity={isMobile ? 0.4 : 0.8}
+        luminanceThreshold={0.6}
+        luminanceSmoothing={0.9}
+        mipmapBlur
+        radius={0.4}
+      />
+      <ToneMapping mode={ToneMappingMode.ACES_FILMIC} />
       <Noise
         premultiply
         blendFunction={BlendFunction.SOFT_LIGHT}
-        opacity={0.5}
+        opacity={0.3}
       />
       <Vignette
         offset={0.5}

--- a/src/components/three/Sun.jsx
+++ b/src/components/three/Sun.jsx
@@ -39,6 +39,28 @@ export function Sun() {
         return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453);
       }
 
+      float noise(vec2 p) {
+        vec2 i = floor(p);
+        vec2 f = fract(p);
+        f = f * f * (3.0 - 2.0 * f);
+        float a = hash(i);
+        float b = hash(i + vec2(1.0, 0.0));
+        float c = hash(i + vec2(0.0, 1.0));
+        float d = hash(i + vec2(1.0, 1.0));
+        return mix(mix(a, b, f.x), mix(c, d, f.x), f.y);
+      }
+
+      float fbm(vec2 p) {
+        float v = 0.0;
+        float a = 0.5;
+        for (int i = 0; i < 4; i++) {
+          v += a * noise(p);
+          p *= 2.0;
+          a *= 0.5;
+        }
+        return v;
+      }
+
       void main() {
         vec3 baseColor = vec3(1.0, 0.6, 0.1);
         vec3 hotColor = vec3(1.0, 0.9, 0.4);
@@ -46,16 +68,21 @@ export function Sun() {
         vec2 uv = vUv;
         float t = time * 0.1;
 
-        float pattern = hash(uv * 8.0 + vec2(t * 0.5, t * 0.7));
+        float pattern = fbm(uv * 6.0 + vec2(t * 0.3, t * 0.2));
+        float pattern2 = fbm(uv * 10.0 - vec2(t * 0.2, t * 0.4));
+        float combined = pattern * 0.7 + pattern2 * 0.3;
 
         float fresnel = pow(1.0 - dot(vNormal, vec3(0.0, 0.0, 1.0)), 2.0);
 
-        vec3 color = mix(baseColor, hotColor, pattern);
+        vec3 color = mix(baseColor, hotColor, combined);
 
         float pulse = sin(time * 0.5) * 0.05 + 0.95;
         color *= pulse;
 
         color += hotColor * fresnel * 0.5;
+
+        // Push into HDR range for bloom
+        color *= 1.8;
 
         gl_FragColor = vec4(color, 1.0);
       }
@@ -65,16 +92,16 @@ export function Sun() {
   const LensFlareSystem = () => {
     const flareTexture = useMemo(() => {
       const canvas = document.createElement("canvas");
-      canvas.width = 128;
-      canvas.height = 128;
+      canvas.width = 256;
+      canvas.height = 256;
       const ctx = canvas.getContext("2d");
-      const gradient = ctx.createRadialGradient(64, 64, 0, 64, 64, 64);
+      const gradient = ctx.createRadialGradient(128, 128, 0, 128, 128, 128);
       gradient.addColorStop(0, "rgba(255, 255, 255, 1.0)");
       gradient.addColorStop(0.1, "rgba(255, 230, 190, 0.8)");
       gradient.addColorStop(0.5, "rgba(255, 150, 50, 0.3)");
       gradient.addColorStop(1, "rgba(255, 100, 50, 0.0)");
       ctx.fillStyle = gradient;
-      ctx.fillRect(0, 0, 128, 128);
+      ctx.fillRect(0, 0, 256, 256);
 
       const texture = new THREE.CanvasTexture(canvas);
       texture.needsUpdate = true;
@@ -83,7 +110,7 @@ export function Sun() {
 
     return (
       <group ref={lensFlareRef} position={[0, 0, 0]}>
-        <sprite position={[0, 0, 0]} scale={[2, 2, 2]}>
+        <sprite position={[0, 0, 0]} scale={[3, 3, 3]}>
           <spriteMaterial
             attach="material"
             map={flareTexture}
@@ -93,13 +120,23 @@ export function Sun() {
             blending={THREE.AdditiveBlending}
           />
         </sprite>
-        <sprite position={[0, 0, -0.2]} scale={[5, 5, 5]}>
+        <sprite position={[0, 0, -0.2]} scale={[7, 7, 7]}>
           <spriteMaterial
             attach="material"
             map={flareTexture}
             transparent
             opacity={0.4}
             color={0xff6622}
+            blending={THREE.AdditiveBlending}
+          />
+        </sprite>
+        <sprite position={[0, 0, -0.4]} scale={[12, 12, 12]}>
+          <spriteMaterial
+            attach="material"
+            map={flareTexture}
+            transparent
+            opacity={0.15}
+            color={0xff4400}
             blending={THREE.AdditiveBlending}
           />
         </sprite>
@@ -111,14 +148,14 @@ export function Sun() {
     <group>
       <pointLight
         position={[0, 0, 0]}
-        intensity={2}
+        intensity={3}
         color={0xffffee}
         distance={100}
         decay={1.5}
         castShadow={false}
       />
       <mesh ref={sunRef}>
-        <sphereGeometry args={[1, 32, 32]} />
+        <sphereGeometry args={[1, 48, 48]} />
         <shaderMaterial
           args={[sunShader]}
           uniforms={sunShader.uniforms}

--- a/src/components/three/shaders.js
+++ b/src/components/three/shaders.js
@@ -7,6 +7,8 @@ export const earthVertexShader = `
   varying vec3 vNormal;
   varying vec3 vViewPosition;
   varying vec3 vWorldPosition;
+  varying vec3 vTangent;
+  varying vec3 vBitangent;
 
   void main() {
     vUv = uv;
@@ -18,6 +20,13 @@ export const earthVertexShader = `
     vViewPosition = -mvPosition.xyz;
 
     vNormal = normalMatrix * normal;
+
+    // Compute tangent for normal mapping on UV-mapped sphere
+    vec3 t = normalize(cross(normal, vec3(0.0, 1.0, 0.0)));
+    if (length(t) < 0.001) t = normalize(cross(normal, vec3(1.0, 0.0, 0.0)));
+    vTangent = normalMatrix * t;
+    vBitangent = cross(vNormal, vTangent);
+
     gl_Position = projectionMatrix * mvPosition;
   }
 `;
@@ -41,28 +50,51 @@ export const earthFragmentShader = `
   varying vec3 vNormal;
   varying vec3 vViewPosition;
   varying vec3 vWorldPosition;
+  varying vec3 vTangent;
+  varying vec3 vBitangent;
 
   void main() {
     vec4 dayColor = texture2D(dayTexture, vUv);
     vec4 nightColor = texture2D(nightTexture, vUv);
-    vec3 normal = normalize(vNormal);
 
-    float sunInfluence = dot(normal, normalize(sunDirection));
+    // Normal mapping — perturb surface normal with the normal map
+    vec3 normalMapSample = texture2D(normalMap, vUv).xyz * 2.0 - 1.0;
+    normalMapSample.xy *= 0.8;
+    mat3 TBN = mat3(normalize(vTangent), normalize(vBitangent), normalize(vNormal));
+    vec3 normal = normalize(TBN * normalMapSample);
+
+    vec3 sunDir = normalize(sunDirection);
+    float sunInfluence = dot(normal, sunDir);
     float mixValue = smoothstep(-0.2, 0.2, sunInfluence);
     vec4 color = mix(nightColor, dayColor, mixValue);
 
-    vec3 atmosphereColor = vec3(0.6, 0.8, 1.0);
-    float atmosphere = pow(1.0 - abs(dot(normal, normalize(vViewPosition))), 2.0);
-    color.rgb += atmosphereColor * atmosphere * max(0.0, sunInfluence) * 0.3;
+    // Atmosphere — two-layer fresnel effect
+    float fresnel = pow(1.0 - abs(dot(normalize(vNormal), normalize(vViewPosition))), 3.0);
+    vec3 atmosphereColor = vec3(0.4, 0.7, 1.0);
+    // Day side: bright atmosphere rim
+    color.rgb += atmosphereColor * fresnel * max(0.0, sunInfluence) * 0.5;
+    // Terminator: subtle warm glow
+    float terminator = 1.0 - smoothstep(-0.1, 0.3, abs(sunInfluence));
+    color.rgb += vec3(1.0, 0.5, 0.2) * fresnel * terminator * 0.15;
 
+    // Night glow
     float nightGlow = pow(max(0.0, -sunInfluence), 2.0) * 0.3;
     color.rgb += nightColor.rgb * nightGlow;
 
+    // Directional lighting
     vec3 lightDir = normalize(directionalLightDirection);
     float diff = max(dot(normal, lightDir), 0.0);
     vec3 lighting = ambientLightColor + directionalLightColor * diff;
     color.rgb *= lighting;
 
+    // Specular highlights — ocean reflections
+    float specularMask = texture2D(specularMap, vUv).r;
+    vec3 viewDir = normalize(vViewPosition);
+    vec3 halfDir = normalize(sunDir + viewDir);
+    float spec = pow(max(dot(normal, halfDir), 0.0), 64.0) * specularMask;
+    color.rgb += vec3(1.0, 0.95, 0.8) * spec * 0.6 * max(0.0, sunInfluence);
+
+    // Ice factor — desaturation
     vec3 gray = vec3(dot(color.rgb, vec3(0.299, 0.587, 0.114)));
     color.rgb = mix(gray, color.rgb, iceFactor);
 
@@ -70,3 +102,42 @@ export const earthFragmentShader = `
   }
 `;
 
+// Atmosphere glow vertex shader
+export const atmosphereVertexShader = `
+  varying vec3 vNormal;
+  varying vec3 vViewPosition;
+
+  void main() {
+    vNormal = normalize(normalMatrix * normal);
+    vec4 mvPos = modelViewMatrix * vec4(position, 1.0);
+    vViewPosition = -mvPos.xyz;
+    gl_Position = projectionMatrix * mvPos;
+  }
+`;
+
+// Atmosphere glow fragment shader
+export const atmosphereFragmentShader = `
+  uniform vec3 sunDirection;
+
+  varying vec3 vNormal;
+  varying vec3 vViewPosition;
+
+  void main() {
+    vec3 normal = normalize(vNormal);
+    vec3 viewDir = normalize(vViewPosition);
+
+    float rim = pow(1.0 - max(0.0, dot(normal, viewDir)), 3.0);
+
+    float sunFacing = dot(-normal, normalize(sunDirection));
+    float dayFactor = smoothstep(-0.2, 0.5, sunFacing);
+
+    vec3 dayColor = vec3(0.3, 0.6, 1.0);
+    vec3 nightColor = vec3(0.05, 0.1, 0.2);
+    vec3 color = mix(nightColor, dayColor, dayFactor);
+
+    float alpha = rim * mix(0.15, 0.6, dayFactor);
+
+    // Push color above 1.0 so bloom picks it up
+    gl_FragColor = vec4(color * 1.5, alpha);
+  }
+`;


### PR DESCRIPTION
…e effects

Add bloom post-processing and ACES filmic tone mapping for a cinematic look. Activate normal map and specular map in the Earth shader (previously loaded but unused) to show terrain relief and ocean reflections. Add a separate atmosphere glow shell mesh with fresnel rim lighting. Replace the Sun's blocky hash noise with smooth 4-octave fbm, boost to HDR for bloom pickup, and add a third corona sprite. Raise DPR to retina, upgrade precision to highp, and enable post-processing on mobile at reduced intensity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Rendering pipeline and custom shader logic are modified (tone mapping, bloom, normal/specular lighting), which can impact visual correctness and performance across devices, especially mobile/retina.
> 
> **Overview**
> Modernizes the scene’s look by enabling HDR-friendly rendering in `StoryContainer` (high precision, higher DPR, disabling Three’s built-in tone mapping) and always running post-processing with mobile-tuned intensity.
> 
> Adds cinematic post effects in `SceneEffects` (bloom + ACES filmic tone mapping, reduced noise), and significantly upgrades Earth/Sun visuals: Earth now uses tangent-space normal mapping and specular highlights in the shader, adds a separate atmosphere glow shell, and increases mesh resolution; Sun shader switches to smoother FBM noise, boosts emissive output for bloom pickup, and enhances lens flare sprites/light intensity.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0387785dbf1e72ca857019918d114004b3e05ef3. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->