### PR TITLE
fix: stop sliders jumping back mid-drag

### DIFF
--- a/src/components/story/PlaygroundSection.jsx
+++ b/src/components/story/PlaygroundSection.jsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState, useEffect, useRef, lazy, Suspense } from "react";
+import React, { useState, useEffect, useRef, useCallback, lazy, Suspense } from "react";
 import { StorySection } from "./StorySection";
 import { ParameterCard } from "./playground/ParameterCard";
 import { TemperaturePod } from "./playground/TemperaturePod";
@@ -113,11 +113,30 @@ export function PlaygroundSection({
     };
   }, []);
 
-  const handleParamChange = (setter) => (v) => {
-    cancelAnim();
-    setter(v);
-    setActiveEraKey(null);
-  };
+  const handleEccentricityInput = useCallback(
+    (v) => {
+      cancelAnim();
+      onEccentricityChange(v);
+      setActiveEraKey(null);
+    },
+    [onEccentricityChange]
+  );
+  const handleAxialTiltInput = useCallback(
+    (v) => {
+      cancelAnim();
+      onAxialTiltChange(v);
+      setActiveEraKey(null);
+    },
+    [onAxialTiltChange]
+  );
+  const handlePrecessionInput = useCallback(
+    (v) => {
+      cancelAnim();
+      onPrecessionChange(v);
+      setActiveEraKey(null);
+    },
+    [onPrecessionChange]
+  );
 
   const focusParam = (key) => {
     clearTimeout(stickyTimer.current);
@@ -191,7 +210,7 @@ export function PlaygroundSection({
               label="Stretch"
               scienceName="Eccentricity"
               value={eccentricity}
-              onChange={handleParamChange(onEccentricityChange)}
+              onChange={handleEccentricityInput}
               min={0.005}
               max={0.058}
               step={0.001}
@@ -208,7 +227,7 @@ export function PlaygroundSection({
               label="Lean"
               scienceName="Obliquity"
               value={axialTilt}
-              onChange={handleParamChange(onAxialTiltChange)}
+              onChange={handleAxialTiltInput}
               min={22.1}
               max={24.5}
               step={0.1}
@@ -225,7 +244,7 @@ export function PlaygroundSection({
               label="Wobble"
               scienceName="Precession"
               value={precession}
-              onChange={handleParamChange(onPrecessionChange)}
+              onChange={handlePrecessionInput}
               min={0}
               max={360}
               step={1}

--- a/src/components/story/StorySlider.jsx
+++ b/src/components/story/StorySlider.jsx
@@ -28,9 +28,10 @@ export function StorySlider({
     typeof todayMark === "number"
       ? ((todayMark - min) / (max - min)) * 100
       : null;
-  const lastUpdate = useRef(0);
   const inputRef = useRef(null);
   const touchStart = useRef(null);
+  const pendingValue = useRef(null);
+  const rafId = useRef(null);
 
   useEffect(() => {
     const el = inputRef.current;
@@ -54,6 +55,13 @@ export function StorySlider({
     };
   }, []);
 
+  useEffect(
+    () => () => {
+      if (rafId.current !== null) cancelAnimationFrame(rafId.current);
+    },
+    []
+  );
+
   const formattedValue =
     typeof value === "number"
       ? formatValue
@@ -64,7 +72,8 @@ export function StorySlider({
       : value;
 
   const maybeSnap = useCallback(
-    (raw) => {
+    (raw, { committing } = { committing: false }) => {
+      if (!committing) return raw;
       if (!snapToToday || typeof todayMark !== "number") return raw;
       const range = max - min;
       if (Math.abs(raw - todayMark) / range < 0.01) return todayMark;
@@ -73,20 +82,32 @@ export function StorySlider({
     [snapToToday, todayMark, max, min]
   );
 
+  const flush = useCallback(() => {
+    rafId.current = null;
+    if (pendingValue.current !== null) {
+      onChange(maybeSnap(pendingValue.current, { committing: false }));
+      pendingValue.current = null;
+    }
+  }, [onChange, maybeSnap]);
+
   const handleInput = useCallback(
     (e) => {
-      const now = performance.now();
-      if (now - lastUpdate.current > 16) {
-        lastUpdate.current = now;
-        onChange(maybeSnap(parseFloat(e.target.value)));
+      pendingValue.current = parseFloat(e.target.value);
+      if (rafId.current === null) {
+        rafId.current = requestAnimationFrame(flush);
       }
     },
-    [onChange, maybeSnap]
+    [flush]
   );
 
   const handleCommit = useCallback(
     (e) => {
-      onChange(maybeSnap(parseFloat(e.target.value)));
+      if (rafId.current !== null) {
+        cancelAnimationFrame(rafId.current);
+        rafId.current = null;
+      }
+      pendingValue.current = null;
+      onChange(maybeSnap(parseFloat(e.target.value), { committing: true }));
     },
     [onChange, maybeSnap]
   );


### PR DESCRIPTION
## Summary

All 6 interactive sliders (Eccentricity / Axial Tilt / Precession sections + 3× Playground `ParameterCard`) share the same `StorySlider` component, which had a drop-based 16ms throttle on `onInput`. Because the `<input type="range">` is controlled, any dropped event left React state behind the native DOM value. When the parent re-rendered mid-drag (most commonly from the temperature-smoothing rAF loop in `StoryContainer`), React reconciled the input back to the stale prop and the thumb visibly snapped backward.

## Changes

- **`StorySlider.jsx`** — replaced the drop-based throttle with rAF coalescing: every input event stores the latest value; the next animation frame flushes it through `onChange`. No event is ever lost, updates are capped at display rate, and the React `value` prop is at most one frame behind the user's cursor so reconciliation no longer fights the drag.
- **`StorySlider.jsx`** — `maybeSnap` now takes a `{ committing }` flag and only snaps to `todayMark` on `pointerUp` / `keyUp`. Crossing the today tick during a drag now feels linear; the value clicks to exactly today on release.
- **`PlaygroundSection.jsx`** — replaced the inline `handleParamChange(setter)` factory (which created a new function every render) with three `useCallback`-memoized handlers.

No API surface change; all callers stay the same.

## Test plan

- [x] Desktop drag — each slider moves 1:1 with the cursor, no snap-back even while temperature smoothing is animating.
- [x] Snap-to-today — mid-drag is linear, commit within ~1% snaps to exact today.
- [x] Keyboard — arrow keys + keyUp still commit.
- [x] No new console errors in dev.
- [ ] Mobile / touch — horizontal drag works, vertical swipe still scrolls (regression check for fix 10ab185).
- [ ] Era buttons — clicking animates smoothly; grabbing a slider mid-animation cancels and follows the cursor without jumping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes input handling semantics for all sliders by coalescing updates via `requestAnimationFrame` and altering snap-to-today behavior to occur only on commit; could affect perceived responsiveness and edge-case interactions (pointer/keyboard/touch).
> 
> **Overview**
> Prevents controlled `StorySlider` thumbs from jumping backward mid-drag by replacing the old 16ms drop-throttle with `requestAnimationFrame` coalescing that always applies the latest pending value.
> 
> Adjusts snap-to-`todayMark` so it only happens on commit events (`pointerUp`/`keyUp`), keeping drag motion linear while still snapping on release.
> 
> In `PlaygroundSection`, replaces the per-render `handleParamChange` factory with memoized `useCallback` handlers for the three `ParameterCard` sliders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de90e916709ac97a3362108316ce3979540528ef. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->