### PR TITLE
fix(mobile): make sliders draggable on touch devices

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -227,7 +227,7 @@
   -webkit-appearance: none;
   appearance: none;
   background: transparent;
-  touch-action: pan-y;
+  touch-action: none;
   -webkit-user-select: none;
   user-select: none;
   cursor: pointer;

--- a/src/components/story/StorySlider.jsx
+++ b/src/components/story/StorySlider.jsx
@@ -28,32 +28,8 @@ export function StorySlider({
     typeof todayMark === "number"
       ? ((todayMark - min) / (max - min)) * 100
       : null;
-  const inputRef = useRef(null);
-  const touchStart = useRef(null);
   const pendingValue = useRef(null);
   const rafId = useRef(null);
-
-  useEffect(() => {
-    const el = inputRef.current;
-    if (!el) return;
-    const onTouchStart = (e) => {
-      const t = e.touches[0];
-      touchStart.current = { x: t.clientX, y: t.clientY };
-    };
-    const onTouchMove = (e) => {
-      if (!touchStart.current) return;
-      const t = e.touches[0];
-      const dx = Math.abs(t.clientX - touchStart.current.x);
-      const dy = Math.abs(t.clientY - touchStart.current.y);
-      if (dx > dy) e.preventDefault();
-    };
-    el.addEventListener("touchstart", onTouchStart, { passive: true });
-    el.addEventListener("touchmove", onTouchMove, { passive: false });
-    return () => {
-      el.removeEventListener("touchstart", onTouchStart);
-      el.removeEventListener("touchmove", onTouchMove);
-    };
-  }, []);
 
   useEffect(
     () => () => {
@@ -157,7 +133,6 @@ export function StorySlider({
         <input
           type="range"
           value={value}
-          ref={inputRef}
           onChange={handleInput}
           onPointerUp={(e) => {
             handleCommit(e);


### PR DESCRIPTION
`touch-action: pan-y` on `.celestial-slider` pre-committed any vertical
component of the gesture to scrolling, so the surrounding scrollable
panel hijacked drags before the native range input could track them —
taps worked, drags didn't. Switch to `touch-action: none` so the slider
keeps the gesture; the panel still scrolls via touches that start on its
background. Removes the now-redundant `touchmove`/`preventDefault`
workaround in StorySlider.

https://claude.ai/code/session_011ziDA6izS3ECT7iyeB2Z81

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, isolated touch-handling changes limited to slider CSS/JS, with the main potential downside being altered scroll/gesture behavior when interacting directly with the slider.
> 
> **Overview**
> Fixes mobile range slider dragging by changing `.celestial-slider` to `touch-action: none`, ensuring the slider retains touch gestures instead of handing them to the surrounding scroll container.
> 
> Removes the now-redundant `touchstart`/`touchmove` event listener workaround (and associated `ref`) from `StorySlider`, relying on native pointer/touch behavior for commits and updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43b044c0e6ab7fae9849e777e9dbe1aed451bb8a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->