### PR TITLE
UX redesign: split-stage scrollytelling, scroll-scrubbed cycles, persistent 65°N climate HUD

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -91,7 +91,9 @@
     letter-spacing: -0.015em;
     margin: 0;
     padding: 0;
-    width: 100vw;
+    /* 100% not 100vw — 100vw includes the scrollbar, which pushed
+       right-anchored UI (nav pill, progress rail) off the visible edge */
+    width: 100%;
     min-height: 100vh;
     overflow-x: hidden;
     overflow-y: auto;
@@ -157,7 +159,7 @@
   background: radial-gradient(
     circle at center, 
     transparent 0%, 
-    hsla(var(--deep-space), 0.4) 100%
+    hsl(var(--deep-space) / 0.4) 100%
   );
   pointer-events: none;
 }
@@ -165,11 +167,11 @@
 /* Custom UI Components */
 .observatory-panel {
   @apply bg-opacity-70 backdrop-blur-md border border-opacity-30 rounded-lg;
-  background-color: hsla(var(--deep-space), 0.7);
-  border-color: hsla(var(--slate-blue), 0.3);
+  background-color: hsl(var(--deep-space) / 0.7);
+  border-color: hsl(var(--slate-blue) / 0.3);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2), 
-              0 0 0 1px hsla(var(--antique-brass), 0.1),
-              inset 0 0 0 1px hsla(var(--stardust-white), 0.05);
+              0 0 0 1px hsl(var(--antique-brass) / 0.1),
+              inset 0 0 0 1px hsl(var(--stardust-white) / 0.05);
 }
 
 .control-panel {
@@ -179,20 +181,20 @@
 /* Custom interactive elements */
 .celestial-button {
   @apply px-4 py-2 rounded-md transition-all duration-300 focus:outline-none;
-  background-color: hsla(var(--deep-space), 0.8);
+  background-color: hsl(var(--deep-space) / 0.8);
   border: 1px solid hsl(var(--stardust-white));
   color: hsl(var(--stardust-white));
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2), 
-              inset 0 0 0 1px hsla(var(--stardust-white), 0.05);
+              inset 0 0 0 1px hsl(var(--stardust-white) / 0.05);
 }
 
 .celestial-button:hover {
-  background-color: hsla(var(--midnight-blue), 0.8);
+  background-color: hsl(var(--midnight-blue) / 0.8);
   border-color: hsl(var(--stardust-white));
   transform: translateY(-1px);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3), 
-              0 0 0 1px hsla(var(--antique-brass), 0.2),
-              inset 0 0 0 1px hsla(var(--stardust-white), 0.1);
+              0 0 0 1px hsl(var(--antique-brass) / 0.2),
+              inset 0 0 0 1px hsl(var(--stardust-white) / 0.1);
 }
 
 .celestial-button:active {
@@ -203,8 +205,8 @@
 /* Data display elements */
 .data-display {
   @apply bg-opacity-60 backdrop-blur-sm p-2 rounded border border-opacity-20 text-sm;
-  background-color: hsla(var(--deep-space), 0.6);
-  border-color: hsla(var(--antique-brass), 0.2);
+  background-color: hsl(var(--deep-space) / 0.6);
+  border-color: hsl(var(--antique-brass) / 0.2);
   color: hsl(var(--pale-gold));
 }
 
@@ -289,8 +291,8 @@
 /* Tooltip styling */
 .celestial-tooltip {
   @apply absolute z-50 px-3 py-2 text-sm rounded-md shadow-lg;
-  background-color: hsla(var(--deep-space), 0.9);
-  border: 1px solid hsla(var(--antique-brass), 0.3);
+  background-color: hsl(var(--deep-space) / 0.9);
+  border: 1px solid hsl(var(--antique-brass) / 0.3);
   backdrop-filter: blur(8px);
   color: hsl(var(--stardust-white));
   max-width: 300px;
@@ -307,9 +309,9 @@
 }
 
 @keyframes pulse-glow {
-  0% { box-shadow: 0 0 5px hsla(var(--antique-brass), 0.3); }
-  50% { box-shadow: 0 0 15px hsla(var(--antique-brass), 0.6); }
-  100% { box-shadow: 0 0 5px hsla(var(--antique-brass), 0.3); }
+  0% { box-shadow: 0 0 5px hsl(var(--antique-brass) / 0.3); }
+  50% { box-shadow: 0 0 15px hsl(var(--antique-brass) / 0.6); }
+  100% { box-shadow: 0 0 5px hsl(var(--antique-brass) / 0.3); }
 }
 
 .animate-glow {
@@ -720,16 +722,16 @@
 }
 
 ::-webkit-scrollbar-track {
-  background: hsla(var(--deep-space), 0.6);
+  background: hsl(var(--deep-space) / 0.6);
 }
 
 ::-webkit-scrollbar-thumb {
-  background: hsla(var(--antique-brass), 0.4);
+  background: hsl(var(--antique-brass) / 0.4);
   border-radius: 3px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: hsla(var(--antique-brass), 0.7);
+  background: hsl(var(--antique-brass) / 0.7);
 }
 
 /* Loading state animations */
@@ -817,13 +819,33 @@
   min-height: 100svh;
 }
 
+/* Inner wrapper holds the flex layout; for pinned sections it sticks while
+   the extra scroll length drives the 3D scene (scroll-scrubbed parameters). */
+.story-sticky {
+  min-height: 100vh;
+  min-height: 100svh;
+}
+
+.story-section--pinned {
+  min-height: 220vh;
+  min-height: 220svh;
+}
+
+@media (max-width: 767px) {
+  .story-section--pinned {
+    min-height: 190vh;
+    min-height: 190svh;
+  }
+}
+
 .story-section .observatory-panel {
-  background-color: hsla(var(--deep-space), 0.85);
+  /* High enough that scene glow (sun, atmosphere) can't wash out the text */
+  background-color: hsl(var(--deep-space) / 0.92);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2),
-              0 0 0 1px hsla(var(--antique-brass), 0.1),
-              inset 0 1px 0 0 hsla(var(--pale-gold), 0.1);
+              0 0 0 1px hsl(var(--antique-brass) / 0.1),
+              inset 0 1px 0 0 hsl(var(--pale-gold) / 0.1);
   position: relative;
 }
 
@@ -847,7 +869,7 @@
 
 /* Scroll line indicator animation */
 .scroll-line {
-  background: linear-gradient(to bottom, hsla(var(--pale-gold), 0.6), transparent);
+  background: linear-gradient(to bottom, hsl(var(--pale-gold) / 0.6), transparent);
   animation: scrollDraw 2s ease-in-out infinite;
 }
 
@@ -880,7 +902,7 @@
    capping their taller content created nested inner scrollbars and
    bottom-anchored overlaps. They flow and scroll with the page instead. */
 @media (max-width: 767px) {
-  :is(#section-1, #section-2, #section-3, #section-4).story-section {
+  :is(#section-1, #section-2, #section-3, #section-4) .story-sticky {
     align-items: flex-end;
     padding-bottom: 1rem;
   }
@@ -895,7 +917,7 @@
   }
 
   .story-section .observatory-panel {
-    background-color: hsla(var(--deep-space), 0.78);
+    background-color: hsl(var(--deep-space) / 0.9);
   }
 }
 
@@ -904,21 +926,21 @@
    this file only holds the focus treatment and its reduced-motion variant. */
 .spotlight-focus {
   box-shadow:
-    0 0 0 1px hsla(var(--antique-brass), 0.5),
-    0 0 24px hsla(var(--antique-brass), 0.25);
+    0 0 0 1px hsl(var(--antique-brass) / 0.5),
+    0 0 24px hsl(var(--antique-brass) / 0.25);
   animation: spotlight-pulse 2.4s ease-in-out infinite;
 }
 
 @keyframes spotlight-pulse {
   0%, 100% {
     box-shadow:
-      0 0 0 1px hsla(var(--antique-brass), 0.5),
-      0 0 20px hsla(var(--antique-brass), 0.22);
+      0 0 0 1px hsl(var(--antique-brass) / 0.5),
+      0 0 20px hsl(var(--antique-brass) / 0.22);
   }
   50% {
     box-shadow:
-      0 0 0 1px hsla(var(--antique-brass), 0.7),
-      0 0 32px hsla(var(--antique-brass), 0.4);
+      0 0 0 1px hsl(var(--antique-brass) / 0.7),
+      0 0 32px hsl(var(--antique-brass) / 0.4);
   }
 }
 
@@ -951,13 +973,15 @@
 /* Playground bottom sheet (mobile). Peek state keeps a 3.5rem grab bar
    visible above the safe area; expanded slides the whole sheet up. */
 .playground-sheet {
-  background-color: hsla(var(--deep-space), 0.88);
+  /* Near-solid: scene glow (Earth atmosphere, sun bloom) bled through the
+     old 0.88 backdrop and washed the expanded sheet out to white-on-white */
+  background-color: hsl(var(--deep-space) / 0.97);
   backdrop-filter: blur(14px);
   -webkit-backdrop-filter: blur(14px);
-  border-top: 1px solid hsla(var(--antique-brass), 0.25);
+  border-top: 1px solid hsl(var(--antique-brass) / 0.25);
   border-radius: 1rem 1rem 0 0;
   box-shadow: 0 -8px 32px rgba(0, 0, 0, 0.45),
-              inset 0 1px 0 0 hsla(var(--pale-gold), 0.1);
+              inset 0 1px 0 0 hsl(var(--pale-gold) / 0.1);
   transform: translateY(0);
   transition: transform 0.35s cubic-bezier(0.32, 0.72, 0, 1);
   animation: sheet-up 0.45s cubic-bezier(0.16, 1, 0.3, 1);

--- a/src/components/story/AxialTiltSection.jsx
+++ b/src/components/story/AxialTiltSection.jsx
@@ -42,7 +42,12 @@ export function AxialTiltSection({ axialTilt, onAxialTiltChange, onInView }) {
             label="Tilt Earth's axis"
             scienceName="Obliquity"
             value={axialTilt}
-            onChange={onAxialTiltChange}
+            onChange={(v) => {
+              // Any real input — pointer or keyboard — takes over from the
+              // scroll scrub; programmatic scrub updates never fire onChange.
+              setUserOwned(true);
+              onAxialTiltChange(v);
+            }}
             min={MIN}
             max={MAX}
             step={0.1}

--- a/src/components/story/AxialTiltSection.jsx
+++ b/src/components/story/AxialTiltSection.jsx
@@ -1,27 +1,39 @@
 "use client";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { StorySection } from "./StorySection";
 import { StorySlider } from "./StorySlider";
 import { CauseEffectCard } from "./CauseEffectCard";
-import { TemperatureIndicator } from "./TemperatureIndicator";
 import { TODAY_TILT } from "@/lib/parameterCopy";
+import { useScrollScrub, scrubSweep } from "@/lib/useScrollScrub";
 
-export function AxialTiltSection({ axialTilt, onAxialTiltChange, temperature, onInView }) {
+const MIN = 22.1;
+const MAX = 24.5;
+
+export function AxialTiltSection({ axialTilt, onAxialTiltChange, onInView }) {
+  const [userOwned, setUserOwned] = useState(false);
+  const scrub = useScrollScrub("section-3", { enabled: !userOwned });
+  const revealed = userOwned || scrub > 0.35;
+
+  useEffect(() => {
+    if (userOwned) return;
+    onAxialTiltChange(scrubSweep(scrub, { min: MIN, max: MAX, today: TODAY_TILT }));
+  }, [scrub, userOwned, onAxialTiltChange]);
+
   return (
-    <StorySection id={3} onInView={onInView}>
-      <div className="w-full max-w-lg px-4 md:px-12 py-4 md:py-8 md:ml-auto">
-        <div className="observatory-panel p-4 md:p-8 space-y-3 md:space-y-6">
+    <StorySection id={3} onInView={onInView} pinned>
+      <div className="w-full max-w-lg px-4 md:px-12 py-4 md:py-8">
+        <div className="observatory-panel p-4 md:p-8 space-y-3 md:space-y-5">
           <div>
             <h2 className="text-2xl md:text-4xl mb-1">The Lean</h2>
-            <span className="text-sm font-mono text-pale-gold opacity-50">Scientists call this: Obliquity / Axial Tilt</span>
+            <span className="text-sm font-mono text-pale-gold opacity-80">Scientists call this: Obliquity / Axial Tilt</span>
           </div>
 
-          <p className="text-sm md:text-base text-stardust-white opacity-80 leading-relaxed">
+          <p className="text-sm md:text-base text-stardust-white opacity-90 leading-relaxed">
             Earth does not spin straight up. Its axis leans, and that lean shifts
             between 22.1° and 24.5° over about <strong className="text-pale-gold">41,000 years</strong>.
           </p>
 
-          <p className="hidden md:block text-sm text-stardust-white opacity-60 leading-relaxed italic">
+          <p className="hidden md:block text-sm text-stardust-white opacity-75 leading-relaxed italic">
             More lean makes summers and winters more intense. Less lean softens the
             seasons. Today, Earth sits near <strong className="text-pale-gold not-italic">23.4°</strong>.
           </p>
@@ -31,20 +43,27 @@ export function AxialTiltSection({ axialTilt, onAxialTiltChange, temperature, on
             scienceName="Obliquity"
             value={axialTilt}
             onChange={onAxialTiltChange}
-            min={22.1}
-            max={24.5}
+            min={MIN}
+            max={MAX}
             step={0.1}
-            hint="Watch the white axis line lean farther from vertical"
+            hint="The white axis line leans as you scroll — or grab the dial"
             minLabel="Less tilt, milder seasons"
             maxLabel="More tilt, stronger seasons"
             todayMark={TODAY_TILT}
             snapToToday
             formatValue={(nextValue) => `${nextValue.toFixed(1)}°`}
+            onPointerDown={() => setUserOwned(true)}
           />
 
-          <TemperatureIndicator temperature={temperature} />
-
-          <div className="hidden md:block">
+          <div
+            className={[
+              "transition-all duration-700",
+              revealed
+                ? "opacity-100 translate-y-0"
+                : "opacity-0 translate-y-3 pointer-events-none max-h-0 overflow-hidden",
+            ].join(" ")}
+            aria-hidden={!revealed}
+          >
             <CauseEffectCard
               items={[
                 "More tilt creates bigger summer and winter contrasts",

--- a/src/components/story/ClimateHUD.jsx
+++ b/src/components/story/ClimateHUD.jsx
@@ -1,0 +1,91 @@
+"use client";
+import React from "react";
+import { TemperatureIndicator } from "./TemperatureIndicator";
+import { getTodayTemperature } from "@/lib/todayClimate";
+
+function compactLabel(t) {
+  if (t < -10) return "Glacial";
+  if (t < -5) return "Cold";
+  if (t < 0) return "Cool";
+  if (t < 5) return "Moderate";
+  return "Warm";
+}
+
+/**
+ * The one climate instrument of the story. Fixed in place across sections so
+ * temperature reads as a continuous character rather than a per-card widget,
+ * and always labeled with the 65°N context so the reading is never mistaken
+ * for Earth's global average.
+ */
+export function ClimateHUD({ temperature, visible }) {
+  const todayTemp = getTodayTemperature();
+  const delta = temperature - todayTemp;
+
+  return (
+    <>
+      {/* Desktop: full instrument, bottom-left */}
+      <div
+        className={[
+          "hidden md:block fixed right-6 bottom-6 z-30 w-72 transition-all duration-500",
+          visible
+            ? "opacity-100 translate-y-0"
+            : "opacity-0 translate-y-4 pointer-events-none",
+        ].join(" ")}
+        aria-hidden={!visible}
+      >
+        <div className="observatory-panel p-4 space-y-2.5">
+          <div className="flex items-baseline justify-between gap-2">
+            <span
+              className="text-[11px] font-mono uppercase tracking-wider text-antique-brass"
+              title="Annual mean temperature at 65° north — the latitude that decides whether ice sheets grow or melt"
+            >
+              Climate at 65°N
+            </span>
+            <span className="text-[11px] text-stardust-white/60">
+              the ice-age trigger zone
+            </span>
+          </div>
+          <TemperatureIndicator temperature={temperature} />
+          <p className="text-[11px] text-stardust-white/60 leading-snug">
+            Not Earth's average (~15°C) — this tracks the far north, where ice
+            ages are won and lost.
+          </p>
+        </div>
+      </div>
+
+      {/* Mobile: compact chip, top-left, clear of the bottom-anchored cards */}
+      <div
+        className={[
+          "md:hidden fixed left-3 top-3 z-30 transition-all duration-500",
+          visible
+            ? "opacity-100 translate-y-0"
+            : "opacity-0 -translate-y-2 pointer-events-none",
+        ].join(" ")}
+        aria-hidden={!visible}
+      >
+        <div className="observatory-panel rounded-full px-3 py-1.5 flex items-center gap-2">
+          <span className="text-[10px] font-mono uppercase tracking-wider text-antique-brass">
+            65°N
+          </span>
+          <span className="text-sm font-mono font-bold text-pale-gold">
+            {temperature.toFixed(1)}°C
+          </span>
+          <span className="text-[10px] text-stardust-white/70">
+            {compactLabel(temperature)}
+          </span>
+          {Math.abs(delta) > 0.15 && (
+            <span
+              className={[
+                "text-[10px] font-mono",
+                delta > 0 ? "text-temp-warm" : "text-temp-cold",
+              ].join(" ")}
+            >
+              {delta > 0 ? "+" : "−"}
+              {Math.abs(delta).toFixed(1)}°
+            </span>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/story/ClosingSection.jsx
+++ b/src/components/story/ClosingSection.jsx
@@ -75,7 +75,7 @@ export function ClosingSection({ onInView, snapshot }) {
           <p className="text-base md:text-lg text-pale-gold font-medium">
             You now understand the 3 orbital cycles that drive ice ages
           </p>
-          <div className="flex flex-wrap justify-center gap-3 md:gap-6 text-sm text-stardust-white opacity-60 font-mono">
+          <div className="flex flex-wrap justify-center gap-3 md:gap-6 text-sm text-stardust-white opacity-75 font-mono">
             <span>The Stretch</span>
             <span className="opacity-30">/</span>
             <span>The Lean</span>
@@ -91,7 +91,7 @@ export function ClosingSection({ onInView, snapshot }) {
             and warm periods — not by invoking catastrophes, but through the
             slow, relentless changes in Earth's orbit."
           </blockquote>
-          <p className="text-sm text-stardust-white opacity-50">
+          <p className="text-sm text-stardust-white opacity-70">
             — Milutin Milankovic, who figured this out in the 1920s with just a
             pencil, paper, and years of calculations.
           </p>
@@ -142,7 +142,7 @@ export function ClosingSection({ onInView, snapshot }) {
 
         {/* Personal connection */}
         <div className="pt-4 border-t border-stardust-white/10">
-          <p className="text-sm text-stardust-white opacity-50">
+          <p className="text-sm text-stardust-white opacity-70">
             Built by Filip van Harreveld — great-grandson of Milutin Milankovic
           </p>
         </div>

--- a/src/components/story/CombinedSection.jsx
+++ b/src/components/story/CombinedSection.jsx
@@ -1,9 +1,21 @@
 "use client";
 import React, { useEffect, useRef, useState } from "react";
 import { StorySection } from "./StorySection";
+import { StorySlider } from "./StorySlider";
+import { ERAS } from "@/lib/eraLookup";
 
-const ICE_AGE = { eccentricity: 0.019, axialTilt: 22.99, precession: 114 };
-const TODAY = { eccentricity: 0.0167, axialTilt: 23.44, precession: 0 };
+// Use the canonical era presets so the live 65°N reading on the climate HUD
+// actually goes cold here — ad-hoc params previously read *warmer* than today.
+const ICE_AGE = {
+  eccentricity: ERAS.iceAge.eccentricity,
+  axialTilt: ERAS.iceAge.axialTilt,
+  precession: ERAS.iceAge.precession,
+};
+const TODAY = {
+  eccentricity: ERAS.today.eccentricity,
+  axialTilt: ERAS.today.axialTilt,
+  precession: ERAS.today.precession,
+};
 const DURATION = 6000;
 const PAUSE = 2000;
 
@@ -19,15 +31,16 @@ function lerpParams(from, to, t) {
   };
 }
 
-export function CombinedSection({ onParamsChange, onInView, temperature }) {
+export function CombinedSection({ onParamsChange, onInView }) {
   const [isAnimating, setIsAnimating] = useState(false);
+  const [userOwned, setUserOwned] = useState(false);
   const [progress, setProgress] = useState(0);
   const [currentParams, setCurrentParams] = useState(ICE_AGE);
   const animationRef = useRef(null);
   const timeoutRef = useRef(null);
 
   useEffect(() => {
-    if (!isAnimating) return;
+    if (!isAnimating || userOwned) return;
 
     let cancelled = false;
 
@@ -78,7 +91,7 @@ export function CombinedSection({ onParamsChange, onInView, temperature }) {
       if (animationRef.current) cancelAnimationFrame(animationRef.current);
       if (timeoutRef.current) clearTimeout(timeoutRef.current);
     };
-  }, [isAnimating, onParamsChange]);
+  }, [isAnimating, userOwned, onParamsChange]);
 
   const handleInView = (id) => {
     setIsAnimating(true);
@@ -91,6 +104,7 @@ export function CombinedSection({ onParamsChange, onInView, temperature }) {
       ([entry]) => {
         if (!entry.isIntersecting) {
           setIsAnimating(false);
+          setUserOwned(false);
           onParamsChange(TODAY);
         }
       },
@@ -102,67 +116,69 @@ export function CombinedSection({ onParamsChange, onInView, temperature }) {
     return () => observer.disconnect();
   }, [onParamsChange]);
 
-  // Interpolated temperature for display
-  const iceTemp = -5;
-  const todayTemp = 14;
-  const displayTemp = iceTemp + (todayTemp - iceTemp) * progress;
+  // User grabs the timeline: stop the replay and let them scrub history
+  const handleTimelineChange = (p) => {
+    setProgress(p);
+    const params = lerpParams(ICE_AGE, TODAY, p);
+    onParamsChange(params);
+    setCurrentParams(params);
+  };
+
+  const yearsAgo = Math.round((1 - progress) * 21000);
+  const timelineReadout =
+    yearsAgo < 250 ? "Today" : `${yearsAgo.toLocaleString()} years ago`;
 
   return (
     <StorySection id={5} onInView={handleInView}>
-      <div className="w-full max-w-2xl mx-auto px-4 md:px-6 text-center py-8">
-        <div className="observatory-panel p-4 md:p-8 space-y-4 md:space-y-6">
+      <div className="w-full max-w-lg px-4 md:px-12 py-8">
+        <div className="observatory-panel p-4 md:p-8 space-y-4 md:space-y-5">
           <h2 className="text-2xl md:text-4xl">When All Three Align</h2>
 
-          <p className="text-sm md:text-base text-stardust-white opacity-80 leading-relaxed">
+          <p className="text-sm md:text-base text-stardust-white opacity-90 leading-relaxed">
             Each of these changes is small on its own. But when they line up in
             just the right way, they can push Earth into an ice age — or pull it
             back out.
           </p>
 
-          {/* Timeline bar */}
-          <div className="space-y-2">
-            <div className="flex justify-between text-xs text-stardust-white opacity-50">
-              <span>21,000 years ago</span>
-              <span>Today</span>
-            </div>
-            <div className="h-2 rounded-full overflow-hidden bg-slate-blue/40">
-              <div
-                className="h-full rounded-full transition-all duration-100"
-                style={{
-                  width: `${progress * 100}%`,
-                  background: `linear-gradient(to right, #2563eb, #06b6d4, #84cc16, #eab308)`,
-                }}
-              />
-            </div>
-            <div className="flex justify-between items-center">
-              <span className="text-sm font-mono text-blue-400">
-                ❄️ {iceTemp}°C
+          {/* Draggable history timeline — replays on its own until grabbed */}
+          <StorySlider
+            label="Travel through time"
+            value={progress}
+            onChange={handleTimelineChange}
+            min={0}
+            max={1}
+            step={0.001}
+            hint={
+              userOwned
+                ? "Drag between the last ice age and today"
+                : "Watch history replay — or grab the dial yourself"
+            }
+            minLabel="Last Ice Age"
+            maxLabel="Today"
+            onPointerDown={() => setUserOwned(true)}
+            renderValue={() => (
+              <span className="text-xs font-mono text-pale-gold opacity-90">
+                {timelineReadout}
               </span>
-              <span className="text-lg font-mono font-bold text-pale-gold">
-                {displayTemp.toFixed(1)}°C
-              </span>
-              <span className="text-sm font-mono text-yellow-400">
-                ☀️ {todayTemp}°C
-              </span>
-            </div>
-          </div>
+            )}
+          />
 
           {/* Live parameter values */}
           <div className="grid grid-cols-3 gap-2 text-xs font-mono">
             <div className="observatory-panel p-2 text-center">
-              <div className="text-stardust-white opacity-50">Stretch</div>
+              <div className="text-stardust-white opacity-70">Stretch</div>
               <div className="text-pale-gold">
                 {currentParams.eccentricity.toFixed(4)}
               </div>
             </div>
             <div className="observatory-panel p-2 text-center">
-              <div className="text-stardust-white opacity-50">Lean</div>
+              <div className="text-stardust-white opacity-70">Lean</div>
               <div className="text-pale-gold">
                 {currentParams.axialTilt.toFixed(2)}°
               </div>
             </div>
             <div className="observatory-panel p-2 text-center">
-              <div className="text-stardust-white opacity-50">Wobble</div>
+              <div className="text-stardust-white opacity-70">Wobble</div>
               <div className="text-pale-gold">
                 {currentParams.precession.toFixed(0)}°
               </div>
@@ -171,10 +187,10 @@ export function CombinedSection({ onParamsChange, onInView, temperature }) {
 
           <div className="observatory-panel p-3 md:p-4 bg-deep-space bg-opacity-50">
             <p className="text-xs md:text-sm text-pale-gold leading-relaxed">
-              The key is summer sunlight at 65° north. When summers there are
-              cool enough that winter snow doesn't fully melt, ice builds up year
-              after year. Eventually, massive ice sheets cover much of North
-              America and Europe.
+              The key is summer sunlight at 65° north — the reading on the
+              climate dial. When summers there are cool enough that winter snow
+              doesn't fully melt, ice builds up year after year. Eventually,
+              massive ice sheets cover much of North America and Europe.
             </p>
           </div>
         </div>

--- a/src/components/story/CombinedSection.jsx
+++ b/src/components/story/CombinedSection.jsx
@@ -116,8 +116,10 @@ export function CombinedSection({ onParamsChange, onInView }) {
     return () => observer.disconnect();
   }, [onParamsChange]);
 
-  // User grabs the timeline: stop the replay and let them scrub history
+  // User grabs the timeline (pointer or keyboard): stop the replay and let
+  // them scrub history — the replay's own updates never fire onChange.
   const handleTimelineChange = (p) => {
+    setUserOwned(true);
     setProgress(p);
     const params = lerpParams(ICE_AGE, TODAY, p);
     onParamsChange(params);

--- a/src/components/story/EarthSunSection.jsx
+++ b/src/components/story/EarthSunSection.jsx
@@ -7,21 +7,23 @@ export function EarthSunSection({ onInView }) {
     <StorySection id={1} onInView={onInView}>
       <div className="w-full max-w-lg px-6 md:px-12 py-8">
         <div className="observatory-panel p-6 md:p-8 space-y-5">
-          <h2 className="text-3xl md:text-4xl mb-4">Earth & Sun</h2>
-          <p className="text-lg text-stardust-white opacity-80 leading-relaxed">
+          <h2 className="text-3xl md:text-4xl mb-4">Earth &amp; Sun</h2>
+          <p className="text-lg text-stardust-white opacity-90 leading-relaxed">
             Earth orbits the Sun once a year. But that orbit isn't a perfect
             circle — and it changes over thousands of years.
           </p>
-          <p className="text-base text-stardust-white opacity-60 leading-relaxed">
+          <p className="text-base text-stardust-white opacity-75 leading-relaxed">
             These slow changes in Earth's orbit affect how much sunlight
             different parts of our planet receive. Over time, this can trigger —
             or end — entire ice ages.
           </p>
 
           {/* Interactive hint */}
-          <div className="observatory-panel p-4 bg-deep-space bg-opacity-50 text-center">
-            <p className="text-sm text-pale-gold opacity-80">
-              👆 The 3D view above shows Earth orbiting the Sun. Keep scrolling to learn about the three orbital changes.
+          <div className="observatory-panel p-4 bg-deep-space bg-opacity-50">
+            <p className="text-sm text-pale-gold opacity-90 leading-relaxed">
+              You're looking at Earth's real path — slightly oval, not a circle.
+              Three slow changes to this picture decide when ice ages come and
+              go. Scroll on to meet them.
             </p>
           </div>
         </div>

--- a/src/components/story/EccentricitySection.jsx
+++ b/src/components/story/EccentricitySection.jsx
@@ -45,7 +45,12 @@ export function EccentricitySection({ eccentricity, onEccentricityChange, onInVi
             label="Stretch the orbit"
             scienceName="Eccentricity"
             value={eccentricity}
-            onChange={onEccentricityChange}
+            onChange={(v) => {
+              // Any real input — pointer or keyboard — takes over from the
+              // scroll scrub; programmatic scrub updates never fire onChange.
+              setUserOwned(true);
+              onEccentricityChange(v);
+            }}
             min={MIN}
             max={MAX}
             step={0.001}

--- a/src/components/story/EccentricitySection.jsx
+++ b/src/components/story/EccentricitySection.jsx
@@ -1,27 +1,42 @@
 "use client";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { StorySection } from "./StorySection";
 import { StorySlider } from "./StorySlider";
 import { CauseEffectCard } from "./CauseEffectCard";
-import { TemperatureIndicator } from "./TemperatureIndicator";
 import { TODAY_ECC } from "@/lib/parameterCopy";
+import { useScrollScrub, scrubSweep } from "@/lib/useScrollScrub";
 
-export function EccentricitySection({ eccentricity, onEccentricityChange, temperature, onInView }) {
+const MIN = 0.005;
+const MAX = 0.058;
+
+export function EccentricitySection({ eccentricity, onEccentricityChange, onInView }) {
+  // Scroll drives the parameter until the visitor grabs the dial themselves
+  const [userOwned, setUserOwned] = useState(false);
+  const scrub = useScrollScrub("section-2", { enabled: !userOwned });
+  const revealed = userOwned || scrub > 0.35;
+
+  useEffect(() => {
+    if (userOwned) return;
+    onEccentricityChange(
+      scrubSweep(scrub, { min: MIN, max: MAX, today: TODAY_ECC })
+    );
+  }, [scrub, userOwned, onEccentricityChange]);
+
   return (
-    <StorySection id={2} onInView={onInView}>
+    <StorySection id={2} onInView={onInView} pinned>
       <div className="w-full max-w-lg px-4 md:px-12 py-4 md:py-8">
-        <div className="observatory-panel p-4 md:p-8 space-y-3 md:space-y-6">
+        <div className="observatory-panel p-4 md:p-8 space-y-3 md:space-y-5">
           <div>
             <h2 className="text-2xl md:text-4xl mb-1">The Stretch</h2>
-            <span className="text-sm font-mono text-pale-gold opacity-50">Scientists call this: Eccentricity</span>
+            <span className="text-sm font-mono text-pale-gold opacity-80">Scientists call this: Eccentricity</span>
           </div>
 
-          <p className="text-sm md:text-base text-stardust-white opacity-80 leading-relaxed">
+          <p className="text-sm md:text-base text-stardust-white opacity-90 leading-relaxed">
             Earth's orbit slowly stretches from almost circular to more oval-shaped,
             and back again. This happens over about <strong className="text-pale-gold">100,000 years</strong>.
           </p>
 
-          <p className="hidden md:block text-sm text-stardust-white opacity-60 leading-relaxed italic">
+          <p className="hidden md:block text-sm text-stardust-white opacity-75 leading-relaxed italic">
             Think of it like stretching a rubber band — when the orbit is more oval,
             Earth sometimes gets closer to the Sun, and sometimes farther away.
           </p>
@@ -31,20 +46,28 @@ export function EccentricitySection({ eccentricity, onEccentricityChange, temper
             scienceName="Eccentricity"
             value={eccentricity}
             onChange={onEccentricityChange}
-            min={0.005}
-            max={0.058}
+            min={MIN}
+            max={MAX}
             step={0.001}
-            hint="Watch the orbit shape change above"
+            hint="The orbit stretches as you scroll — or grab the dial"
             minLabel="Rounder orbit"
             maxLabel="More oval orbit"
             todayMark={TODAY_ECC}
             snapToToday
             formatValue={(nextValue) => nextValue.toFixed(3)}
+            onPointerDown={() => setUserOwned(true)}
           />
 
-          <TemperatureIndicator temperature={temperature} />
-
-          <div className="hidden md:block">
+          {/* The payoff for watching (or playing): why this matters */}
+          <div
+            className={[
+              "transition-all duration-700",
+              revealed
+                ? "opacity-100 translate-y-0"
+                : "opacity-0 translate-y-3 pointer-events-none max-h-0 overflow-hidden",
+            ].join(" ")}
+            aria-hidden={!revealed}
+          >
             <CauseEffectCard
               items={[
                 "More oval orbit",

--- a/src/components/story/HeroSection.jsx
+++ b/src/components/story/HeroSection.jsx
@@ -2,42 +2,55 @@
 import React from "react";
 import { StorySection } from "./StorySection";
 
+const CYCLES = [
+  { name: "The Stretch", period: "100,000-year cycle", section: 2 },
+  { name: "The Lean", period: "41,000-year cycle", section: 3 },
+  { name: "The Wobble", period: "26,000-year cycle", section: 4 },
+];
+
 export function HeroSection({ onInView }) {
+  const jumpTo = (i) => {
+    document
+      .getElementById(`section-${i}`)
+      ?.scrollIntoView({ behavior: "smooth" });
+  };
+
   return (
     <StorySection id={0} onInView={onInView} className="justify-center">
-      <div className="w-full max-w-3xl mx-auto px-8 text-center">
-        <h1 className="text-6xl md:text-8xl lg:text-9xl mb-6 leading-[0.95]">
+      <div className="w-full max-w-4xl mx-auto px-8 text-center">
+        <h1 className="text-6xl md:text-8xl lg:text-9xl mb-6 leading-[0.95] text-balance">
           Why Do Ice Ages Happen?
         </h1>
-        <p className="text-xl md:text-2xl text-stardust-white opacity-70 mb-10 leading-relaxed">
+        <p className="text-xl md:text-2xl text-stardust-white opacity-80 mb-3 leading-relaxed">
           The answer is written in the shape of Earth's orbit.
         </p>
+        <p className="text-xs md:text-sm font-mono tracking-wider text-antique-brass mb-12">
+          Built by Milutin Milanković's great-grandson
+        </p>
 
-        {/* What you'll learn mini-outline */}
-        <div className="max-w-sm mx-auto text-left space-y-3 mb-16 opacity-60">
-          <div className="flex items-start gap-3">
-            <span className="text-pale-gold text-sm font-mono mt-0.5 opacity-60">01</span>
-            <p className="text-sm text-stardust-white leading-relaxed">
-              You'll learn about <strong className="text-pale-gold">3 slow changes</strong> in Earth's orbit
-            </p>
-          </div>
-          <div className="flex items-start gap-3">
-            <span className="text-pale-gold text-sm font-mono mt-0.5 opacity-60">02</span>
-            <p className="text-sm text-stardust-white leading-relaxed">
-              Each one takes <strong className="text-pale-gold">thousands of years</strong>
-            </p>
-          </div>
-          <div className="flex items-start gap-3">
-            <span className="text-pale-gold text-sm font-mono mt-0.5 opacity-60">03</span>
-            <p className="text-sm text-stardust-white leading-relaxed">
-              Together, they <strong className="text-pale-gold">cause ice ages</strong>
-            </p>
-          </div>
+        {/* The three cycles — a tease of the journey, each one a shortcut */}
+        <div className="flex flex-wrap justify-center gap-3 mb-14">
+          {CYCLES.map((cycle) => (
+            <button
+              key={cycle.section}
+              onClick={() => jumpTo(cycle.section)}
+              className="group border border-antique-brass/30 rounded-lg px-4 py-2.5 bg-deep-space/50 backdrop-blur-sm hover:border-antique-brass/70 hover:bg-midnight-blue/60 transition-all text-left"
+            >
+              <span className="block font-serif text-base md:text-lg text-pale-gold leading-snug">
+                {cycle.name}
+              </span>
+              <span className="block text-[11px] font-mono text-stardust-white/60 group-hover:text-stardust-white/80 transition-colors">
+                {cycle.period}
+              </span>
+            </button>
+          ))}
         </div>
 
         {/* Custom scroll indicator — descending line */}
-        <div className="scroll-indicator mt-4 text-stardust-white opacity-40 flex flex-col items-center gap-2">
-          <span className="text-xs font-mono tracking-widest uppercase">Scroll to explore</span>
+        <div className="scroll-indicator mt-4 text-stardust-white opacity-50 flex flex-col items-center gap-2">
+          <span className="text-xs font-mono tracking-widest uppercase">
+            Scroll to explore
+          </span>
           <div className="w-px h-12 scroll-line" />
         </div>
       </div>

--- a/src/components/story/PlaygroundSection.jsx
+++ b/src/components/story/PlaygroundSection.jsx
@@ -400,7 +400,7 @@ export function PlaygroundSection({
               <h2 className="text-xl md:text-2xl leading-tight">
                 Conduct the Climate
               </h2>
-              <p className="text-xs text-stardust-white/60 leading-snug mt-1">
+              <p className="text-xs text-stardust-white/75 leading-snug mt-1">
                 Move one dial at a time to feel its fingerprint on Earth's
                 climate — then play them together.
               </p>
@@ -487,7 +487,7 @@ export function PlaygroundSection({
             }}
           >
             <div className="flex items-start justify-between gap-3">
-              <p className="text-xs text-stardust-white/60 leading-snug">
+              <p className="text-xs text-stardust-white/75 leading-snug">
                 Move one dial at a time to feel its fingerprint on Earth's
                 climate. Collapse this panel to see the orbit.
               </p>
@@ -510,7 +510,7 @@ export function PlaygroundSection({
                     ?.scrollIntoView({ behavior: "smooth" });
                 }, 80);
               }}
-              className="w-full text-center text-xs text-stardust-white/60 hover:text-pale-gold transition-colors py-3"
+              className="w-full text-center text-xs text-stardust-white/75 hover:text-pale-gold transition-colors py-3"
             >
               Continue the story ↓
             </button>

--- a/src/components/story/PrecessionSection.jsx
+++ b/src/components/story/PrecessionSection.jsx
@@ -42,7 +42,12 @@ export function PrecessionSection({ precession, onPrecessionChange, onInView }) 
             label="Spin the wobble"
             scienceName="Precession"
             value={precession}
-            onChange={onPrecessionChange}
+            onChange={(v) => {
+              // Any real input — pointer or keyboard — takes over from the
+              // scroll scrub; programmatic scrub updates never fire onChange.
+              setUserOwned(true);
+              onPrecessionChange(v);
+            }}
             min={0}
             max={360}
             step={1}

--- a/src/components/story/PrecessionSection.jsx
+++ b/src/components/story/PrecessionSection.jsx
@@ -1,29 +1,38 @@
 "use client";
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { StorySection } from "./StorySection";
 import { StorySlider } from "./StorySlider";
 import { CauseEffectCard } from "./CauseEffectCard";
-import { TemperatureIndicator } from "./TemperatureIndicator";
 import { TODAY_PREC } from "@/lib/parameterCopy";
+import { useScrollScrub, scrubRevolution } from "@/lib/useScrollScrub";
 
-export function PrecessionSection({ precession, onPrecessionChange, temperature, onInView }) {
+export function PrecessionSection({ precession, onPrecessionChange, onInView }) {
+  const [userOwned, setUserOwned] = useState(false);
+  const scrub = useScrollScrub("section-4", { enabled: !userOwned });
+  const revealed = userOwned || scrub > 0.35;
+
+  useEffect(() => {
+    if (userOwned) return;
+    onPrecessionChange(scrubRevolution(scrub));
+  }, [scrub, userOwned, onPrecessionChange]);
+
   return (
-    <StorySection id={4} onInView={onInView}>
-      <div className="w-full max-w-lg px-4 md:px-12 py-4 md:py-8 md:ml-auto">
-        <div className="observatory-panel p-4 md:p-8 space-y-3 md:space-y-6">
+    <StorySection id={4} onInView={onInView} pinned>
+      <div className="w-full max-w-lg px-4 md:px-12 py-4 md:py-8">
+        <div className="observatory-panel p-4 md:p-8 space-y-3 md:space-y-5">
           <div>
             <h2 className="text-2xl md:text-4xl mb-1">The Wobble</h2>
-            <span className="text-sm font-mono text-pale-gold opacity-50">Scientists call this: Axial Precession</span>
+            <span className="text-sm font-mono text-pale-gold opacity-80">Scientists call this: Axial Precession</span>
           </div>
 
-          <p className="text-sm md:text-base text-stardust-white opacity-80 leading-relaxed">
+          <p className="text-sm md:text-base text-stardust-white opacity-90 leading-relaxed">
             Earth's tilt doesn't just lean — the <em>direction</em> of that lean slowly
             traces a circle, like a spinning top winding down. One full cycle takes
             about <strong className="text-pale-gold">26,000 years</strong>.
           </p>
 
-          <p className="hidden md:block text-sm text-stardust-white opacity-60 leading-relaxed italic">
-            Watch the dashed circle in the 3D view — that's the path the axis traces.
+          <p className="hidden md:block text-sm text-stardust-white opacity-75 leading-relaxed italic">
+            The dashed circle in the 3D view is the path the axis traces.
             This wobble changes which season happens when Earth is closest to the Sun.
             Right now, northern winters happen near the closest point.
             In 13,000 years, northern summers will instead.
@@ -37,17 +46,24 @@ export function PrecessionSection({ precession, onPrecessionChange, temperature,
             min={0}
             max={360}
             step={1}
-            hint="Watch the axis tip move along the dashed circle above"
+            hint="The axis tip circles the dashed ring as you scroll — or grab the dial"
             minLabel="Today's orientation"
             maxLabel="Full cycle (back to start)"
             todayMark={TODAY_PREC}
             snapToToday
             formatValue={(nextValue) => `${nextValue.toFixed(0)}°`}
+            onPointerDown={() => setUserOwned(true)}
           />
 
-          <TemperatureIndicator temperature={temperature} />
-
-          <div className="hidden md:block">
+          <div
+            className={[
+              "transition-all duration-700",
+              revealed
+                ? "opacity-100 translate-y-0"
+                : "opacity-0 translate-y-3 pointer-events-none max-h-0 overflow-hidden",
+            ].join(" ")}
+            aria-hidden={!revealed}
+          >
             <CauseEffectCard
               items={[
                 "Wobble changes which hemisphere faces the Sun at closest approach",

--- a/src/components/story/SceneController.jsx
+++ b/src/components/story/SceneController.jsx
@@ -3,21 +3,32 @@ import React, { useRef, useEffect } from "react";
 import { useThree, useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
-// Camera positions and lookAt targets per section
+// Camera positions, lookAt targets and stage composition per section.
+//
+// `stage` shifts the rendered view so the 3D subject sits in the open zone
+// beside the narrative column instead of behind it. Fractions of the
+// viewport: positive x moves the scene right, positive y moves it up.
+// Desktop cards live in a left column → scene composes right (+x).
+// Mobile cards anchor to the bottom → scene composes up (+y).
 const SCENE_CONFIGS = {
-  0: { // Hero - moderately close view centered on orbit, Earth always visible
-    camera: [0, 15, 35],
-    lookAt: [0, 0, 0],
+  0: { // Hero - close on a half-lit Earth, low in the frame behind the title
+    camera: [14, 2.5, 9],
+    cameraMobile: [8, 3.5, 14],
+    lookAt: [20, 0, 0],
     showSun: false,
     showOrbit: false,
     showAxis: false,
+    stage: { x: 0.3, y: -0.22 },
+    stageMobile: { x: 0.14, y: -0.4 },
   },
-  1: { // Earth & Sun - reveal orbit
+  1: { // Earth & Sun - pull back to reveal the whole orbit
     camera: [0, 30, 50],
     lookAt: [0, 0, 0],
     showSun: true,
     showOrbit: true,
     showAxis: false,
+    stage: { x: 0.16, y: 0 },
+    stageMobile: { x: 0, y: 0.12 },
   },
   2: { // Eccentricity - top down
     camera: [0, 55, 5],
@@ -25,6 +36,8 @@ const SCENE_CONFIGS = {
     showSun: true,
     showOrbit: true,
     showAxis: false,
+    stage: { x: 0.16, y: 0 },
+    stageMobile: { x: 0, y: 0.12 },
   },
   3: { // Axial Tilt - side view close to Earth
     camera: [18, 5, 15],
@@ -32,6 +45,8 @@ const SCENE_CONFIGS = {
     showSun: true,
     showOrbit: false,
     showAxis: true,
+    stage: { x: 0.18, y: 0 },
+    stageMobile: { x: 0, y: 0.12 },
   },
   4: { // Precession - same view as tilt section, with orbit for seasonal context
     camera: [18, 5, 15],
@@ -39,6 +54,8 @@ const SCENE_CONFIGS = {
     showSun: true,
     showOrbit: true,
     showAxis: true,
+    stage: { x: 0.18, y: 0 },
+    stageMobile: { x: 0, y: 0.12 },
   },
   5: { // Combined - overview
     camera: [0, 35, 55],
@@ -46,13 +63,17 @@ const SCENE_CONFIGS = {
     showSun: true,
     showOrbit: true,
     showAxis: true,
+    stage: { x: 0.16, y: 0 },
+    stageMobile: { x: 0, y: 0.12 },
   },
-  6: { // Playground - user controls camera via OrbitControls
+  6: { // Playground - user controls camera; panel sits right, scene left
     camera: [0, 30, 60],
     lookAt: [0, 0, 0],
     showSun: true,
     showOrbit: true,
     showAxis: true,
+    stage: { x: -0.22, y: 0 },
+    stageMobile: { x: 0, y: 0.1 },
   },
   7: { // Closing - cinematic pullback
     camera: [0, 12, 30],
@@ -60,20 +81,29 @@ const SCENE_CONFIGS = {
     showSun: false,
     showOrbit: false,
     showAxis: false,
+    stage: { x: 0, y: 0 },
+    stageMobile: { x: 0, y: 0 },
   },
 };
 
-export function SceneController({ currentSection, onSceneConfig }) {
-  const { camera } = useThree();
+export function SceneController({ currentSection, onSceneConfig, isMobile = false }) {
+  const { camera, size } = useThree();
   const targetPos = useRef(new THREE.Vector3(0, 30, 60));
   const targetLookAt = useRef(new THREE.Vector3(0, 0, 0));
   const currentLookAt = useRef(new THREE.Vector3(0, 0, 0));
+  const targetShift = useRef({ x: 0, y: 0 });
+  const currentShift = useRef({ x: 0, y: 0 });
   const prevSection = useRef(currentSection);
 
   useEffect(() => {
     const config = SCENE_CONFIGS[currentSection] || SCENE_CONFIGS[0];
-    targetPos.current.set(...config.camera);
+    const cameraPos =
+      (isMobile && config.cameraMobile) || config.camera;
+    targetPos.current.set(...cameraPos);
     targetLookAt.current.set(...config.lookAt);
+
+    const stage = (isMobile ? config.stageMobile : config.stage) || { x: 0, y: 0 };
+    targetShift.current = stage;
 
     // When entering playground (section 6), snap camera to position once
     // then let OrbitControls take over completely — no lerping, no fighting
@@ -99,9 +129,27 @@ export function SceneController({ currentSection, onSceneConfig }) {
         showAxis: config.showAxis,
       });
     }
-  }, [currentSection, onSceneConfig, camera]);
+  }, [currentSection, onSceneConfig, camera, isMobile]);
 
   useFrame(() => {
+    // Stage composition applies in every section, including the playground —
+    // it only offsets the projection, so OrbitControls is unaffected.
+    const shift = currentShift.current;
+    shift.x += (targetShift.current.x - shift.x) * 0.04;
+    shift.y += (targetShift.current.y - shift.y) * 0.04;
+    if (Math.abs(shift.x) > 0.002 || Math.abs(shift.y) > 0.002) {
+      camera.setViewOffset(
+        size.width,
+        size.height,
+        -shift.x * size.width,
+        shift.y * size.height,
+        size.width,
+        size.height
+      );
+    } else if (camera.view?.enabled) {
+      camera.clearViewOffset();
+    }
+
     // Completely yield camera control in playground — OrbitControls owns it
     if (currentSection === 6) return;
 

--- a/src/components/story/StoryContainer.jsx
+++ b/src/components/story/StoryContainer.jsx
@@ -2,7 +2,7 @@
 import React, { useState, useCallback, useEffect, Suspense, useRef } from "react";
 import { useIsMobile } from "@/lib/useIsMobile";
 import { Canvas } from "@react-three/fiber";
-import { OrbitControls, PerspectiveCamera } from "@react-three/drei";
+import { OrbitControls, PerspectiveCamera, Stars } from "@react-three/drei";
 import * as THREE from "three";
 
 import { Sun } from "@/components/three/Sun";
@@ -11,6 +11,7 @@ import { OrbitingEarth } from "@/components/three/OrbitingEarth";
 import { SceneEffects } from "@/components/three/SceneEffects";
 import { SceneController } from "./SceneController";
 import { StoryProgressBar } from "./StoryProgressBar";
+import { ClimateHUD } from "./ClimateHUD";
 
 import { HeroSection } from "./HeroSection";
 import { EarthSunSection } from "./EarthSunSection";
@@ -117,6 +118,38 @@ export function StoryContainer() {
     setCurrentSection(id);
   }, []);
 
+  // Authoritative section tracking: whichever section sits under the viewport
+  // center wins. The per-section IntersectionObservers still drive section
+  // side effects, but they can miss transitions during fast or smooth
+  // scrolling and leave the scene config stale — this never does.
+  useEffect(() => {
+    let frame = null;
+    const update = () => {
+      frame = null;
+      const center = window.innerHeight / 2;
+      for (let i = 0; i < TOTAL_SECTIONS; i++) {
+        const el = document.getElementById(`section-${i}`);
+        if (!el) continue;
+        const rect = el.getBoundingClientRect();
+        if (rect.top <= center && rect.bottom > center) {
+          setCurrentSection(i);
+          break;
+        }
+      }
+    };
+    const onScroll = () => {
+      if (frame === null) frame = requestAnimationFrame(update);
+    };
+    update();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll);
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+      if (frame !== null) cancelAnimationFrame(frame);
+    };
+  }, []);
+
   const handleSceneConfig = useCallback((config) => {
     setSceneConfig(config);
   }, []);
@@ -178,6 +211,18 @@ export function StoryContainer() {
             <SceneController
               currentSection={currentSection}
               onSceneConfig={handleSceneConfig}
+              isMobile={isMobile}
+            />
+
+            {/* Subtle starfield gives the observatory a sky */}
+            <Stars
+              radius={250}
+              depth={60}
+              count={isMobile ? 1200 : 2200}
+              factor={3}
+              saturation={0}
+              fade
+              speed={0.4}
             />
 
             {/* 3D Elements - visibility controlled by scene config */}
@@ -188,6 +233,7 @@ export function StoryContainer() {
                 showLabels={currentSection >= 4}
                 currentSection={currentSection}
                 spotlight={effectiveFocus}
+                isMobile={isMobile}
               />
             )}
             <OrbitingEarth
@@ -266,6 +312,13 @@ export function StoryContainer() {
         totalSections={TOTAL_SECTIONS}
       />
 
+      {/* The one climate instrument of the story — persistent across the
+          three cycle sections and the combined view */}
+      <ClimateHUD
+        temperature={displayedTemp}
+        visible={currentSection >= 2 && currentSection <= 5}
+      />
+
       {/* Scrollable content sections */}
       <div className="relative z-10">
         <HeroSection onInView={handleSectionInView} />
@@ -273,25 +326,21 @@ export function StoryContainer() {
         <EccentricitySection
           eccentricity={eccentricity}
           onEccentricityChange={setEccentricity}
-          temperature={temperature}
           onInView={handleSectionInView}
         />
         <AxialTiltSection
           axialTilt={axialTilt}
           onAxialTiltChange={setAxialTilt}
-          temperature={temperature}
           onInView={handleSectionInView}
         />
         <PrecessionSection
           precession={precession}
           onPrecessionChange={setPrecession}
-          temperature={temperature}
           onInView={handleSectionInView}
         />
         <CombinedSection
           onParamsChange={handleCombinedParamsChange}
           onInView={handleSectionInView}
-          temperature={temperature}
         />
         <PlaygroundSection
           eccentricity={eccentricity}

--- a/src/components/story/StoryProgressBar.jsx
+++ b/src/components/story/StoryProgressBar.jsx
@@ -57,12 +57,13 @@ export function StoryProgressBar({ currentSection, totalSections }) {
           className="group flex items-center gap-2 py-1"
           aria-label={`Go to ${SECTION_LABELS[i]}`}
         >
-          {/* Label - visible on hover or when active */}
+          {/* Label - visible on hover or when active. Rendered as a pill so
+              it stays legible even when it overlaps panel content. */}
           <span
-            className={`text-xs font-mono whitespace-nowrap transition-all duration-300 ${
+            className={`text-xs font-mono whitespace-nowrap rounded-full px-2.5 py-1 bg-deep-space/85 backdrop-blur-sm border border-antique-brass/25 transition-all duration-300 ${
               currentSection === i
-                ? "opacity-80 text-pale-gold translate-x-0"
-                : "opacity-0 group-hover:opacity-60 text-stardust-white translate-x-2 group-hover:translate-x-0"
+                ? "opacity-100 text-pale-gold translate-x-0"
+                : "opacity-0 group-hover:opacity-90 text-stardust-white translate-x-2 group-hover:translate-x-0"
             }`}
           >
             {SECTION_LABELS[i]}

--- a/src/components/story/StorySection.jsx
+++ b/src/components/story/StorySection.jsx
@@ -1,7 +1,13 @@
 "use client";
 import React, { useRef, useEffect } from "react";
 
-export function StorySection({ id, children, className = "", onInView }) {
+export function StorySection({
+  id,
+  children,
+  className = "",
+  onInView,
+  pinned = false,
+}) {
   const ref = useRef(null);
 
   useEffect(() => {
@@ -29,9 +35,19 @@ export function StorySection({ id, children, className = "", onInView }) {
     <section
       ref={ref}
       id={`section-${id}`}
-      className={`story-section relative min-h-screen flex items-center ${className}`}
+      className={`story-section relative ${
+        pinned ? "story-section--pinned" : ""
+      }`}
     >
-      {children}
+      {/* Pinned sections are taller than the viewport; this inner wrapper
+          sticks while the scroll drives the 3D scene behind it. */}
+      <div
+        className={`story-sticky ${
+          pinned ? "sticky top-0" : ""
+        } flex items-center ${className}`}
+      >
+        {children}
+      </div>
     </section>
   );
 }

--- a/src/components/story/StorySlider.jsx
+++ b/src/components/story/StorySlider.jsx
@@ -112,16 +112,14 @@ export function StorySlider({
         {renderValue ? (
           renderValue(value)
         ) : scienceName ? (
-          <span className="text-xs font-mono text-pale-gold opacity-60">
+          <span className="text-xs font-mono text-pale-gold opacity-80">
             {scienceName}: {formattedValue}
           </span>
         ) : null}
       </div>
 
       {hint && (
-        <p className="text-sm text-pale-gold opacity-70 flex items-center gap-1">
-          <span className="inline-block animate-bounce text-xs">↑</span> {hint}
-        </p>
+        <p className="text-sm text-pale-gold opacity-90">{hint}</p>
       )}
 
       <div
@@ -174,11 +172,11 @@ export function StorySlider({
           todayPct !== null ? "pb-4" : "",
         ].join(" ")}
       >
-        <span className="opacity-40">{minLabel || min}</span>
+        <span className="opacity-70">{minLabel || min}</span>
         {todayPct !== null && (
           <span
             aria-hidden="true"
-            className="absolute -translate-x-1/2 text-[10px] font-mono text-pale-gold/60 whitespace-nowrap"
+            className="absolute -translate-x-1/2 text-[11px] font-mono text-pale-gold/80 whitespace-nowrap"
             style={{
               left: `clamp(16px, ${todayPct}%, calc(100% - 16px))`,
               top: "1.1rem",
@@ -187,7 +185,7 @@ export function StorySlider({
             ↑ {todayLabel}
           </span>
         )}
-        <span className="text-right opacity-40">{maxLabel || max}</span>
+        <span className="text-right opacity-70">{maxLabel || max}</span>
       </div>
     </div>
   );

--- a/src/components/story/TemperatureIndicator.jsx
+++ b/src/components/story/TemperatureIndicator.jsx
@@ -92,7 +92,7 @@ export function TemperatureIndicator({ temperature }) {
             </span>
           )}
         </div>
-        <span className="text-sm text-stardust-white opacity-60">{getLabel()}</span>
+        <span className="text-sm text-stardust-white opacity-80">{getLabel()}</span>
       </div>
 
       {/* Gradient bar — uses celestial palette */}
@@ -123,15 +123,15 @@ export function TemperatureIndicator({ temperature }) {
         />
       </div>
       <div className="relative flex justify-between text-xs text-stardust-white">
-        <span className="opacity-30">Cold</span>
+        <span className="opacity-60">Cold</span>
         <span
           aria-hidden="true"
-          className="absolute top-0 -translate-x-1/2 text-[10px] font-mono text-pale-gold/60"
+          className="absolute top-0 -translate-x-1/2 text-[11px] font-mono text-pale-gold/80"
           style={{ left: `${todayPct}%` }}
         >
           today
         </span>
-        <span className="opacity-30">Warm</span>
+        <span className="opacity-60">Warm</span>
       </div>
     </div>
   );

--- a/src/components/story/playground/TemperaturePod.jsx
+++ b/src/components/story/playground/TemperaturePod.jsx
@@ -94,10 +94,10 @@ export function TemperaturePod({
     <div className="observatory-panel p-3 md:p-4 space-y-2.5 w-full md:w-60">
       <div className="flex items-center justify-between">
         <span
-          className="text-[10px] font-mono uppercase tracking-wider text-pale-gold/50"
+          className="text-[10px] font-mono uppercase tracking-wider text-antique-brass"
           title="Annual mean at 65°N — the latitude that drives glacial cycles"
         >
-          Climate · 65°N
+          Climate at 65°N
         </span>
         <span className="text-xs text-stardust-white/70">{label(temperature)}</span>
       </div>
@@ -151,10 +151,10 @@ export function TemperaturePod({
       </div>
 
       <div className="flex items-center justify-between text-[11px]">
-        <span className="text-stardust-white/50">
-          Ice <span className="font-mono text-pale-gold/70">{icePct}%</span>
+        <span className="text-stardust-white/70">
+          Ice <span className="font-mono text-pale-gold/80">{icePct}%</span>
         </span>
-        <span className="text-[10px] font-mono text-pale-gold/50">
+        <span className="text-[10px] font-mono text-pale-gold/75">
           today {todayTemp.toFixed(1)}°C
         </span>
         <span className="text-pale-gold/70 font-mono">

--- a/src/components/three/AxisIndicators.jsx
+++ b/src/components/three/AxisIndicators.jsx
@@ -3,7 +3,10 @@ import React, { useEffect, useMemo } from "react";
 import * as THREE from "three";
 import { Html, Line } from "@react-three/drei";
 
-export const AxisIndicators = React.memo(function AxisIndicators({ spotlight = null }) {
+export const AxisIndicators = React.memo(function AxisIndicators({
+  spotlight = null,
+  labelVisible = true,
+}) {
   const arrow = useMemo(
     () =>
       new THREE.ArrowHelper(
@@ -56,24 +59,27 @@ export const AxisIndicators = React.memo(function AxisIndicators({ spotlight = n
   return (
     <group>
       <primitive object={arrow} />
-      <Html position={[0, 5.2, 0]} center>
-        <div
-          style={{
-            color: "white",
-            background: "rgba(0, 0, 0, 0.7)",
-            padding: "4px 8px",
-            borderRadius: "4px",
-            fontSize: "12px",
-            fontFamily: "'Courier New', Courier, monospace",
-            backdropFilter: "blur(4px)",
-            border: "1px solid rgba(255, 255, 255, 0.1)",
-            opacity: labelOpacity,
-            transition: "opacity 300ms ease",
-          }}
-        >
-          Rotation Axis
-        </div>
-      </Html>
+      {labelVisible && (
+        <Html position={[0, 5.6, 0]} center>
+          <div
+            style={{
+              color: "hsl(35, 60%, 76%)",
+              backgroundColor: "hsla(230, 33%, 5%, 0.8)",
+              padding: "3px 9px",
+              borderRadius: "9999px",
+              fontSize: "11px",
+              fontFamily: "'Space Mono', 'Courier New', monospace",
+              whiteSpace: "nowrap",
+              border: "1px solid hsla(36, 60%, 58%, 0.35)",
+              letterSpacing: "0.02em",
+              opacity: labelOpacity,
+              transition: "opacity 300ms ease",
+            }}
+          >
+            Rotation Axis
+          </div>
+        </Html>
+      )}
     </group>
   );
 });

--- a/src/components/three/Earth.jsx
+++ b/src/components/three/Earth.jsx
@@ -12,7 +12,15 @@ import { AxisIndicators } from "./AxisIndicators";
 
 export const Earth = React.forwardRef(
   (
-    { axialTilt, precession, iceFactor, onReady, showAxis = true, spotlight = null },
+    {
+      axialTilt,
+      precession,
+      iceFactor,
+      onReady,
+      showAxis = true,
+      axisLabelVisible = true,
+      spotlight = null,
+    },
     ref
   ) => {
     const [texturesLoaded, setTexturesLoaded] = useState(false);
@@ -169,7 +177,9 @@ export const Earth = React.forwardRef(
           />
         </mesh>
 
-        {showAxis ? <AxisIndicators spotlight={spotlight} /> : null}
+        {showAxis ? (
+          <AxisIndicators spotlight={spotlight} labelVisible={axisLabelVisible} />
+        ) : null}
       </group>
     );
   }

--- a/src/components/three/OrbitPath.jsx
+++ b/src/components/three/OrbitPath.jsx
@@ -22,11 +22,26 @@ const SEASON_LABELS = [
   "Fall (N. Hemisphere)",
 ];
 
+// Shared chip styling for every in-scene annotation — observatory style,
+// deliberately glow-free so labels never wash out the UI panels above them.
+const labelChipStyle = {
+  color: "hsl(35, 60%, 76%)",
+  backgroundColor: "hsla(230, 33%, 5%, 0.8)",
+  padding: "3px 9px",
+  borderRadius: "9999px",
+  fontSize: "11px",
+  fontFamily: "'Space Mono', 'Courier New', monospace",
+  whiteSpace: "nowrap",
+  border: "1px solid hsla(36, 60%, 58%, 0.35)",
+  letterSpacing: "0.02em",
+};
+
 export const OrbitPath = React.memo(function OrbitPath({
   eccentricity,
   showLabels = true,
   currentSection = 0,
   spotlight = null,
+  isMobile = false,
 }) {
   const a = A;
   const b = a * (1 - 2 * eccentricity);
@@ -122,35 +137,27 @@ export const OrbitPath = React.memo(function OrbitPath({
         opacity={Math.min(1, 0.4 * boost) * orbitFade}
       />
 
+      {/* Pulled in from the orbit's extremes so they never clip the viewport
+          edge or collide with the progress rail / narrative column. */}
       {showDistanceLabels && (
         <>
-          <Html position={[-a + 2, 2, 0]} center>
+          <Html position={[-a * (isMobile ? 0.32 : 0.55), 2, 0]} center>
             <div
               style={{
-                color: "#ef4444",
-                backgroundColor: "rgba(239, 68, 68, 0.15)",
-                padding: "3px 10px",
-                borderRadius: "12px",
-                fontSize: "13px",
-                fontWeight: "600",
-                whiteSpace: "nowrap",
-                border: "1px solid rgba(239, 68, 68, 0.4)",
+                ...labelChipStyle,
+                color: "#f3978f",
+                border: "1px solid rgba(227, 105, 98, 0.45)",
               }}
             >
               ← Farther from Sun
             </div>
           </Html>
-          <Html position={[a - 2, 2, 0]} center>
+          <Html position={[a * (isMobile ? 0.32 : 0.55), 2, 0]} center>
             <div
               style={{
+                ...labelChipStyle,
                 color: "#fbbf24",
-                backgroundColor: "rgba(251, 191, 36, 0.15)",
-                padding: "3px 10px",
-                borderRadius: "12px",
-                fontSize: "13px",
-                fontWeight: "600",
-                whiteSpace: "nowrap",
-                border: "1px solid rgba(251, 191, 36, 0.4)",
+                border: "1px solid rgba(251, 191, 36, 0.45)",
               }}
             >
               Closer to Sun →
@@ -164,65 +171,59 @@ export const OrbitPath = React.memo(function OrbitPath({
           style={{
             color: "#fbbf24",
             fontSize: "11px",
-            fontWeight: "500",
+            fontFamily: "'Space Mono', 'Courier New', monospace",
             whiteSpace: "nowrap",
-            opacity: 0.7 * orbitFade,
-            textShadow: "0 0 8px rgba(251, 191, 36, 0.5)",
+            opacity: 0.8 * orbitFade,
           }}
         >
-          Sun ☀️
+          Sun
         </div>
       </Html>
 
-      {seasonalMarkers.map((position, index) => (
-        <group key={index} position={position}>
-          <mesh>
-            <sphereGeometry args={[0.3, 16, 16]} />
-            <meshBasicMaterial
-              color={index % 2 === 0 ? "#cdaf7d" : "#e36962"}
-              transparent
-              opacity={1 * markerFade}
-            />
-          </mesh>
-          <mesh scale={1.2}>
-            <sphereGeometry args={[0.3, 16, 16]} />
-            <meshBasicMaterial
-              color={index % 2 === 0 ? "#cdaf7d" : "#e36962"}
-              transparent
-              opacity={0.6 * markerFade}
-            />
-          </mesh>
-          <mesh scale={1.4}>
-            <sphereGeometry args={[0.3, 16, 16]} />
-            <meshBasicMaterial
-              color={index % 2 === 0 ? "#cdaf7d" : "#e36962"}
-              transparent
-              opacity={0.3 * markerFade}
-            />
-          </mesh>
-          {showLabels && (
-            <Html position={[0, 1, 0]} center>
-              <div
-                style={{
-                  color: "white",
-                  backgroundColor: "rgba(205, 175, 125, 0.6)",
-                  padding: "4px 8px",
-                  borderRadius: "4px",
-                  fontSize: "12px",
-                  whiteSpace: "nowrap",
-                  backdropFilter: "blur(4px)",
-                  border: "1px solid rgba(232, 208, 169, 0.8)",
-                  textShadow: "0 0 10px rgba(232, 208, 169, 1)",
-                  boxShadow: "0 0 20px rgba(205, 175, 125, 0.5)",
-                  opacity: markerFade,
-                }}
-              >
-                {seasonLabels[index]}
-              </div>
-            </Html>
-          )}
-        </group>
-      ))}
+      {seasonalMarkers.map((position, index) => {
+        // Label budget: only Winter and Summer (the pair precession actually
+        // swaps) carry labels in the story; Spring/Fall labels appear only on
+        // the desktop playground where there's room to read all four.
+        const isKeySeason = index === 0 || index === 2;
+        const showThisLabel =
+          showLabels &&
+          (isKeySeason || (currentSection === 6 && !isMobile));
+        return (
+          <group key={index} position={position}>
+            <mesh>
+              <sphereGeometry args={[0.3, 16, 16]} />
+              <meshBasicMaterial
+                color={index % 2 === 0 ? "#cdaf7d" : "#e36962"}
+                transparent
+                opacity={1 * markerFade}
+              />
+            </mesh>
+            <mesh scale={1.2}>
+              <sphereGeometry args={[0.3, 16, 16]} />
+              <meshBasicMaterial
+                color={index % 2 === 0 ? "#cdaf7d" : "#e36962"}
+                transparent
+                opacity={0.6 * markerFade}
+              />
+            </mesh>
+            <mesh scale={1.4}>
+              <sphereGeometry args={[0.3, 16, 16]} />
+              <meshBasicMaterial
+                color={index % 2 === 0 ? "#cdaf7d" : "#e36962"}
+                transparent
+                opacity={0.3 * markerFade}
+              />
+            </mesh>
+            {showThisLabel && (
+              <Html position={[0, 1, 0]} center>
+                <div style={{ ...labelChipStyle, opacity: markerFade }}>
+                  {seasonLabels[index]}
+                </div>
+              </Html>
+            )}
+          </group>
+        );
+      })}
     </group>
   );
 });

--- a/src/components/three/OrbitingEarth.jsx
+++ b/src/components/three/OrbitingEarth.jsx
@@ -31,7 +31,9 @@ export const OrbitingEarth = React.memo(function OrbitingEarth({
   useFrame((_, delta) => {
     if (!groupRef.current || !isReady) return;
 
-    const isPinnedSection = currentSection === 3 || currentSection === 4;
+    // Hero pins Earth too, so the close-up camera always has its subject
+    const isPinnedSection =
+      currentSection === 0 || currentSection === 3 || currentSection === 4;
     if (!isPinnedSection) {
       orbitThetaRef.current += delta * 0.1;
     }
@@ -73,6 +75,7 @@ export const OrbitingEarth = React.memo(function OrbitingEarth({
         iceFactor={iceFactor}
         onReady={onEarthReady}
         showAxis={showAxis}
+        axisLabelVisible={currentSection === 3 || currentSection === 4}
         spotlight={spotlight}
       />
       {/* Precession cone is outside Earth's quaternion group so it stays fixed */}

--- a/src/lib/useScrollScrub.js
+++ b/src/lib/useScrollScrub.js
@@ -1,0 +1,67 @@
+"use client";
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Maps the scroll position of a pinned story section to 0..1 progress.
+ * 0 = section top reaches the viewport top (card just pinned),
+ * 1 = section bottom reaches the viewport bottom (pin about to release).
+ *
+ * Used to drive an orbital parameter from scroll so every visitor sees the
+ * effect of each cycle, even if they never touch a slider.
+ */
+export function useScrollScrub(sectionId, { enabled = true } = {}) {
+  const [progress, setProgress] = useState(0);
+  const frame = useRef(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const el = document.getElementById(sectionId);
+    if (!el) return;
+
+    const update = () => {
+      frame.current = null;
+      const rect = el.getBoundingClientRect();
+      const total = rect.height - window.innerHeight;
+      if (total <= 0) return;
+      setProgress(Math.min(1, Math.max(0, -rect.top / total)));
+    };
+    const onScroll = () => {
+      if (frame.current === null) frame.current = requestAnimationFrame(update);
+    };
+    update();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll);
+    return () => {
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+      if (frame.current !== null) cancelAnimationFrame(frame.current);
+    };
+  }, [sectionId, enabled]);
+
+  return progress;
+}
+
+function easeInOut(p) {
+  return p < 0.5 ? 2 * p * p : 1 - Math.pow(-2 * p + 2, 2) / 2;
+}
+
+/**
+ * Sweep a parameter across its full range as the user scrolls through a
+ * pinned section, always returning home to today's value:
+ * hold today → rise to max → fall to min → settle back at today.
+ */
+export function scrubSweep(p, { min, max, today }) {
+  if (p < 0.1) return today;
+  if (p < 0.45) return today + (max - today) * easeInOut((p - 0.1) / 0.35);
+  if (p < 0.8) return max + (min - max) * easeInOut((p - 0.45) / 0.35);
+  return min + (today - min) * easeInOut((p - 0.8) / 0.2);
+}
+
+/**
+ * Precession is an angle: one full revolution per scrub, ending back at 0°.
+ */
+export function scrubRevolution(p) {
+  if (p < 0.1) return 0;
+  if (p > 0.9) return 0;
+  return 360 * easeInOut((p - 0.1) / 0.8);
+}


### PR DESCRIPTION
## What changed

A full-experience redesign of the story, from an awwwards-level UX review of the live site (desktop 1440×900 and mobile 375×812).

**The 3D scene becomes the protagonist.** Story cards now live in a fixed left column and the camera composes each section's subject (orbit, Earth, axis) into the open stage beside them via per-section view offsets in `SceneController` — previously the cards sat on top of the very thing the copy asked you to watch ("Watch the white axis line lean…" while Earth was behind the card).

**Scroll teaches the cycles.** The Stretch/Lean/Wobble sections are pinned (220svh) and the scroll position sweeps each parameter through its full range and home to today (`useScrollScrub`). Grabbing the slider takes over instantly; the cause→effect card reveals as the payoff for watching or playing.

**One climate instrument.** New `ClimateHUD` (bottom-right desktop, compact chip top-left mobile) carries the 65°N reading across sections 2–5, always labeled "Climate at 65°N — the ice-age trigger zone" with a "not Earth's average (~15°C)" footnote. Kills the "−8.3°C today??" confusion, and replaces the per-card temperature bars.

**Hero**: large half-lit Earth + starfield, the three cycles as clickable chips, and the byline surfaced from the footer: *Built by Milutin Milanković's great-grandson*.

**Combined section**: the timeline is now draggable (auto-replays until grabbed) and uses the canonical `ERAS` presets.

## Two real bugs this surfaced (both fixed here)

1. **Every panel was actually transparent.** All 34 `hsla(var(--token), alpha)` declarations in `globals.css` mix space-separated HSL tokens with comma-alpha — invalid CSS, silently dropped. The "glassy" panels were backdrop-blur only, which is why scene glow washed out the mobile bottom sheet (white-on-white), the Combined readout, and the closing quote. Now `hsl(var(--token) / alpha)`.
2. **The "ice age" was warmer than today.** `CombinedSection`'s ad-hoc `ICE_AGE` params scored **+7.9 °C** at 65°N in the model; the old hardcoded −5/14 °C display masked it. It now animates between the calibrated `ERAS.iceAge`/`ERAS.today` presets and shows honest live readings.

Also: center-of-viewport section detector (the per-section IntersectionObservers could miss transitions and leave the playground scene rendering behind the closing quote), glow-free observatory-style 3D label chips with a per-section label budget and safe-area positions, rail labels as pills, a contrast pass on muted text, and `body` width `100vw→100%` so right-anchored UI stops clipping.

## Reviewer notes

- Page height grows: the three pinned sections add ~1.2 viewport heights each to the scroll length — intentional, that travel is what drives the parameter sweep.
- The `hsl()` syntax fix makes all panels render their declared backgrounds for the first time, so the whole site reads slightly more solid/darker than before — that's the design as originally written in the stylesheet.
- `npm run test:scene` has one **pre-existing** failure (present-day global temp computes 9.17 °C vs expected ~15 °C). No model code is touched in this PR, but the new HUD footnote says "~15 °C global average", so the model calibration is worth a follow-up look.
- Verified by walking all 8 sections at both viewports with screenshots: no label/card/rail overlaps, expanded mobile sheet fully legible, scrub→slider handoff works, console clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)